### PR TITLE
Reformating and updated docstrings.

### DIFF
--- a/pyvex/IRConst/__init__.py
+++ b/pyvex/IRConst/__init__.py
@@ -1,6 +1,6 @@
 from .. import VEXObject
 
-# IRConst heirarchy
+# IRConst hierarchy
 class IRConst(VEXObject):
     type = None
 

--- a/pyvex/IRExpr/__init__.py
+++ b/pyvex/IRExpr/__init__.py
@@ -1,7 +1,9 @@
 from .. import VEXObject
 
-# IRExpr heirarchy
 class IRExpr(VEXObject):
+    """
+    IR expressions in VEX represent operations without side effects.
+    """
     def __init__(self, c_expr, irsb):
         VEXObject.__init__(self)
         self.tag = ints_to_enums[c_expr.tag]
@@ -19,9 +21,9 @@ class IRExpr(VEXObject):
 
     @property
     def child_expressions(self):
-        '''
+        """
         A list of all of the expressions that this expression ends up evaluating.
-        '''
+        """
         expressions = [ ]
         for _,v in self.__dict__.iteritems():
             if isinstance(v, IRExpr):
@@ -31,9 +33,9 @@ class IRExpr(VEXObject):
 
     @property
     def constants(self):
-        '''
+        """
         A list of all of the constants that this expression ends up using.
-        '''
+        """
         constants = [ ]
         for _,v in self.__dict__.iteritems():
             if isinstance(v, IRExpr):
@@ -56,6 +58,9 @@ class IRExpr(VEXObject):
         return expr_class(c_expr, irsb)
 
 class Binder(IRExpr):
+    """
+    Used only in pattern matching within Vex. Should not be seen outside of Vex.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.binder = c_expr.iex.Binder.binder
@@ -80,6 +85,9 @@ class BBPTR(IRExpr):
         return "BBPTR"
 
 class GetI(IRExpr):
+    """
+    Read a guest register at a non-fixed offset in the guest state.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.descr = IRRegArray(c_expr.Iex.GetI.descr)
@@ -98,6 +106,9 @@ class GetI(IRExpr):
         return "GetI(%s)[%s,%s]" % (self.descr, self.ix, self.bias)
 
 class RdTmp(IRExpr):
+    """
+    Read the value held by a temporary.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.tmp = c_expr.Iex.RdTmp.tmp
@@ -106,6 +117,9 @@ class RdTmp(IRExpr):
         return "t%d" % self.tmp
 
 class Get(IRExpr):
+    """
+    Read a guest register, at a fixed offset in the guest state.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.offset = c_expr.Iex.Get.offset
@@ -119,6 +133,9 @@ class Get(IRExpr):
         return "GET:%s(%s)" % (self.ty[4:], self.arch.translate_register_name(self.offset))
 
 class Qop(IRExpr):
+    """
+    A quaternary operation (4 arguments).
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.op = ints_to_enums[c_expr.Iex.Qop.details.op]
@@ -139,6 +156,9 @@ class Qop(IRExpr):
         return expressions
 
 class Triop(IRExpr):
+    """
+    A ternary operation (3 arguments)
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.op = ints_to_enums[c_expr.Iex.Triop.details.op]
@@ -158,6 +178,9 @@ class Triop(IRExpr):
         return expressions
 
 class Binop(IRExpr):
+    """
+    A binary operation (2 arguments).
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.op = ints_to_enums[c_expr.Iex.Binop.op]
@@ -176,6 +199,9 @@ class Binop(IRExpr):
         return expressions
 
 class Unop(IRExpr):
+    """
+    A unary operation (1 argument).
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.op = ints_to_enums[c_expr.Iex.Unop.op]
@@ -193,6 +219,9 @@ class Unop(IRExpr):
         return expressions
 
 class Load(IRExpr):
+    """
+    A load from memory.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.end = ints_to_enums[c_expr.Iex.Load.end]
@@ -211,6 +240,9 @@ class Load(IRExpr):
         return "LD%s:%s(%s)" % (self.end[-2:].lower(), self.ty[4:], self.addr)
 
 class Const(IRExpr):
+    """
+    A constant expression.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.con = IRConst._translate(c_expr.Iex.Const.con)
@@ -219,6 +251,9 @@ class Const(IRExpr):
         return str(self.con)
 
 class ITE(IRExpr):
+    """
+    An if-then-else expression.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.cond = IRExpr._translate(c_expr.Iex.ITE.cond, irsb)
@@ -229,6 +264,9 @@ class ITE(IRExpr):
         return "ITE(%s,%s,%s)" % (self.cond, self.iftrue, self.iffalse)
 
 class CCall(IRExpr):
+    """
+    A call to a pure (no side-effects) helper C function.
+    """
     def __init__(self, c_expr, irsb):
         IRExpr.__init__(self, c_expr, irsb)
         self.retty = ints_to_enums[c_expr.Iex.CCall.retty]

--- a/pyvex/IRStmt/__init__.py
+++ b/pyvex/IRStmt/__init__.py
@@ -1,269 +1,331 @@
 from .. import VEXObject
 
-# IRStmt heirarchy
+
 class IRStmt(VEXObject):
-	def __init__(self, c_stmt, irsb):
-		VEXObject.__init__(self)
-		self.arch = irsb.arch
-		#self.c_stmt = c_stmt
-		self.tag = ints_to_enums[c_stmt.tag]
+    """
+    IR statements in VEX represents operations with side-effects.
+    """
+    def __init__(self, c_stmt, irsb):
+        VEXObject.__init__(self)
+        self.arch = irsb.arch
+        # self.c_stmt = c_stmt
+        self.tag = ints_to_enums[c_stmt.tag]
 
-	def pp(self):
-		print self.__str__()
+    def pp(self):
+        print self.__str__()
 
-	@property
-	def expressions(self):
-		expressions = [ ]
-		for _,v in self.__dict__.iteritems():
-			if isinstance(v, IRExpr):
-				expressions.append(v)
-				expressions.extend(v.child_expressions)
-		return expressions
+    @property
+    def expressions(self):
+        expressions = []
+        for _, v in self.__dict__.iteritems():
+            if isinstance(v, IRExpr):
+                expressions.append(v)
+                expressions.extend(v.child_expressions)
+        return expressions
 
-	@property
-	def constants(self):
-		return sum((e.constants for e in self.expressions), [ ])
+    @property
+    def constants(self):
+        return sum((e.constants for e in self.expressions), [])
 
-	@staticmethod
-	def _translate(c_stmt, irsb):
-		if c_stmt[0] == ffi.NULL:
-			return None
+    @staticmethod
+    def _translate(c_stmt, irsb):
+        if c_stmt[0] == ffi.NULL:
+            return None
 
-		tag = c_stmt.tag
-		try:
-			stmt_class = _tag_to_class[tag]
-		except KeyError:
-			raise PyVEXError('Unknown/unsupported IRStmtTag %s\n' % ints_to_enums[tag])
-		return stmt_class(c_stmt, irsb)
+        tag = c_stmt.tag
+        try:
+            stmt_class = _tag_to_class[tag]
+        except KeyError:
+            raise PyVEXError('Unknown/unsupported IRStmtTag %s\n' % ints_to_enums[tag])
+        return stmt_class(c_stmt, irsb)
+
 
 class NoOp(IRStmt):
-	def __init__(self, c_stmt, irsb): #pylint:disable=unused-argument
-		IRStmt.__init__(self, c_stmt, irsb)
+    """
+    A no-operation statement. It is usually the result of an IR optimization.
+    """
+    def __init__(self, c_stmt, irsb):  # pylint:disable=unused-argument
+        IRStmt.__init__(self, c_stmt, irsb)
 
-	def __str__(self):
-		return "IR-NoOp"
+    def __str__(self):
+        return "IR-NoOp"
+
 
 class IMark(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
-		self.addr = c_stmt.Ist.IMark.addr
-		self.len = c_stmt.Ist.IMark.len
-		self.delta = c_stmt.Ist.IMark.delta
+    """
+    An instruction mark. It marks the start of the statements that represent a single machine instruction (the end of
+    those statements is marked by the next IMark or the end of the IRSB).  Contains the address and length of the
+    instruction.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
+        self.addr = c_stmt.Ist.IMark.addr
+        self.len = c_stmt.Ist.IMark.len
+        self.delta = c_stmt.Ist.IMark.delta
 
-	def __str__(self):
-		return "------ IMark(0x%x, %d, %d) ------" % (self.addr, self.len, self.delta)
+    def __str__(self):
+        return "------ IMark(0x%x, %d, %d) ------" % (self.addr, self.len, self.delta)
+
 
 class AbiHint(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
-		self.base = IRExpr._translate(c_stmt.Ist.AbiHint.base, irsb)
-		self.len = c_stmt.Ist.AbiHint.len
-		self.nia = IRExpr._translate(c_stmt.Ist.AbiHint.nia, irsb)
+    """
+    An ABI hint, provides specific information about this platform's ABI.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
+        self.base = IRExpr._translate(c_stmt.Ist.AbiHint.base, irsb)
+        self.len = c_stmt.Ist.AbiHint.len
+        self.nia = IRExpr._translate(c_stmt.Ist.AbiHint.nia, irsb)
 
-	def __str__(self):
-		return "====== AbiHint(0x%s, %d, %s) ======" % (self.base, self.len, self.nia)
+    def __str__(self):
+        return "====== AbiHint(0x%s, %d, %s) ======" % (self.base, self.len, self.nia)
+
 
 class Put(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
-		self.data = IRExpr._translate(c_stmt.Ist.Put.data, irsb)
-		self.offset = c_stmt.Ist.Put.offset
+    """
+    Write to a guest register, at a fixed offset in the guest state.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
+        self.data = IRExpr._translate(c_stmt.Ist.Put.data, irsb)
+        self.offset = c_stmt.Ist.Put.offset
 
-	def __str__(self):
-		return "PUT(%s) = %s" % (self.arch.translate_register_name(self.offset), self.data)
+    def __str__(self):
+        return "PUT(%s) = %s" % (self.arch.translate_register_name(self.offset), self.data)
+
 
 class PutI(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
-		self.descr = IRRegArray(c_stmt.Ist.PutI.details.descr)
-		self.ix = IRExpr._translate(c_stmt.Ist.PutI.details.ix, irsb)
-		self.data = IRExpr._translate(c_stmt.Ist.PutI.details.data, irsb)
-		self.bias = c_stmt.Ist.PutI.details.bias
+    """
+    Write to a guest register, at a non-fixed offset in the guest state.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
+        self.descr = IRRegArray(c_stmt.Ist.PutI.details.descr)
+        self.ix = IRExpr._translate(c_stmt.Ist.PutI.details.ix, irsb)
+        self.data = IRExpr._translate(c_stmt.Ist.PutI.details.data, irsb)
+        self.bias = c_stmt.Ist.PutI.details.bias
 
-	def __str__(self):
-		return "PutI(%s)[%s,%d] = %s" % (self.descr, self.ix, self.bias, self.data)
+    def __str__(self):
+        return "PutI(%s)[%s,%d] = %s" % (self.descr, self.ix, self.bias, self.data)
+
 
 class WrTmp(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
+    """
+    Assign a value to a temporary.  Note that SSA rules require each tmp is only assigned to once.  IR sanity checking
+    will reject any block containing a temporary which is not assigned to exactly once.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
 
-		self.data = IRExpr._translate(c_stmt.Ist.WrTmp.data, irsb)
-		self.tmp = c_stmt.Ist.WrTmp.tmp
+        self.data = IRExpr._translate(c_stmt.Ist.WrTmp.data, irsb)
+        self.tmp = c_stmt.Ist.WrTmp.tmp
 
-	def __str__(self):
-		return "t%d = %s" % (self.tmp, self.data)
+    def __str__(self):
+        return "t%d = %s" % (self.tmp, self.data)
+
 
 class Store(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
+    """
+    Write a value to memory..
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
 
-		self.addr = IRExpr._translate(c_stmt.Ist.Store.addr, irsb)
-		self.data = IRExpr._translate(c_stmt.Ist.Store.data, irsb)
-		self.end = ints_to_enums[c_stmt.Ist.Store.end]
+        self.addr = IRExpr._translate(c_stmt.Ist.Store.addr, irsb)
+        self.data = IRExpr._translate(c_stmt.Ist.Store.data, irsb)
+        self.end = ints_to_enums[c_stmt.Ist.Store.end]
 
-	@property
-	def endness(self):
-		return self.end
+    @property
+    def endness(self):
+        return self.end
 
-	def __str__(self):
-		return "ST%s(%s) = %s" % (self.endness[-2:].lower(), self.addr, self.data)
+    def __str__(self):
+        return "ST%s(%s) = %s" % (self.endness[-2:].lower(), self.addr, self.data)
+
 
 class CAS(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
+    """
+    an atomic compare-and-swap operation.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
 
-		self.addr = IRExpr._translate(c_stmt.Ist.CAS.details.addr, irsb)
-		self.dataLo = IRExpr._translate(c_stmt.Ist.CAS.details.dataLo, irsb)
-		self.dataHi = IRExpr._translate(c_stmt.Ist.CAS.details.dataHi, irsb)
-		self.expdLo = IRExpr._translate(c_stmt.Ist.CAS.details.expdLo, irsb)
-		self.expdHi = IRExpr._translate(c_stmt.Ist.CAS.details.expdHi, irsb)
-		self.oldLo = c_stmt.Ist.CAS.details.oldLo
-		self.oldHi = c_stmt.Ist.CAS.details.oldHi
-		self.end = ints_to_enums[c_stmt.Ist.CAS.details.end]
+        self.addr = IRExpr._translate(c_stmt.Ist.CAS.details.addr, irsb)
+        self.dataLo = IRExpr._translate(c_stmt.Ist.CAS.details.dataLo, irsb)
+        self.dataHi = IRExpr._translate(c_stmt.Ist.CAS.details.dataHi, irsb)
+        self.expdLo = IRExpr._translate(c_stmt.Ist.CAS.details.expdLo, irsb)
+        self.expdHi = IRExpr._translate(c_stmt.Ist.CAS.details.expdHi, irsb)
+        self.oldLo = c_stmt.Ist.CAS.details.oldLo
+        self.oldHi = c_stmt.Ist.CAS.details.oldHi
+        self.end = ints_to_enums[c_stmt.Ist.CAS.details.end]
 
-	@property
-	def endness(self):
-		return self.end
+    @property
+    def endness(self):
+        return self.end
 
-	def __str__(self):
-		return "t(%s,%s) = CAS%s(%s :: (%s,%s)->(%s,%s))" % (self.oldLo, self.oldHi, self.end[-2:].lower(), self.addr, self.expdLo, self.expdHi, self.dataLo, self.dataHi)
+    def __str__(self):
+        return "t(%s,%s) = CAS%s(%s :: (%s,%s)->(%s,%s))" % (
+        self.oldLo, self.oldHi, self.end[-2:].lower(), self.addr, self.expdLo, self.expdHi, self.dataLo, self.dataHi)
+
 
 class LLSC(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
+    """
+     Either Load-Linked or Store-Conditional, depending on STOREDATA. If STOREDATA is NULL then this is a Load-Linked,
+     else it is a Store-Conditional.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
 
-		self.addr = IRExpr._translate(c_stmt.Ist.LLSC.addr, irsb)
-		self.storedata = IRExpr._translate(c_stmt.Ist.LLSC.storedata, irsb)
-		self.result = c_stmt.Ist.LLSC.result
-		self.end = ints_to_enums[c_stmt.Ist.LLSC.end]
+        self.addr = IRExpr._translate(c_stmt.Ist.LLSC.addr, irsb)
+        self.storedata = IRExpr._translate(c_stmt.Ist.LLSC.storedata, irsb)
+        self.result = c_stmt.Ist.LLSC.result
+        self.end = ints_to_enums[c_stmt.Ist.LLSC.end]
 
-	@property
-	def endness(self):
-		return self.end
+    @property
+    def endness(self):
+        return self.end
 
-	def __str__(self):
-		if self.storedata is None:
-			return "t%d = LD%s-Linked(%s)" % (self.result, self.end[-2:].lower(), self.addr)
-		else:
-			return "t%d = ( ST%s-Cond(%s) = %s )" % (self.result, self.end[-2:].lower(), self.addr, self.storedata)
+    def __str__(self):
+        if self.storedata is None:
+            return "t%d = LD%s-Linked(%s)" % (self.result, self.end[-2:].lower(), self.addr)
+        else:
+            return "t%d = ( ST%s-Cond(%s) = %s )" % (self.result, self.end[-2:].lower(), self.addr, self.storedata)
+
 
 class MBE(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
-		self.event = ints_to_enums[c_stmt.Ist.MBE.event]
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
+        self.event = ints_to_enums[c_stmt.Ist.MBE.event]
 
-	def __str__(self):
-		return "MBusEvent-" + self.event
+    def __str__(self):
+        return "MBusEvent-" + self.event
+
 
 class Dirty(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
-		self.cee = IRCallee(c_stmt.Ist.Dirty.details.cee)
-		self.guard = IRExpr._translate(c_stmt.Ist.Dirty.details.guard, irsb)
-		self.tmp = c_stmt.Ist.Dirty.details.tmp
-		self.mFx = ints_to_enums[c_stmt.Ist.Dirty.details.mFx]
-		self.mAddr = IRExpr._translate(c_stmt.Ist.Dirty.details.mAddr, irsb)
-		self.mSize = c_stmt.Ist.Dirty.details.mSize
-		self.nFxState = c_stmt.Ist.Dirty.details.nFxState
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
+        self.cee = IRCallee(c_stmt.Ist.Dirty.details.cee)
+        self.guard = IRExpr._translate(c_stmt.Ist.Dirty.details.guard, irsb)
+        self.tmp = c_stmt.Ist.Dirty.details.tmp
+        self.mFx = ints_to_enums[c_stmt.Ist.Dirty.details.mFx]
+        self.mAddr = IRExpr._translate(c_stmt.Ist.Dirty.details.mAddr, irsb)
+        self.mSize = c_stmt.Ist.Dirty.details.mSize
+        self.nFxState = c_stmt.Ist.Dirty.details.nFxState
 
-		self.args = [ ]
-		for i in range(20):
-			a = c_stmt.Ist.Dirty.details.args[i]
-			if a == ffi.NULL:
-				break
+        self.args = []
+        for i in range(20):
+            a = c_stmt.Ist.Dirty.details.args[i]
+            if a == ffi.NULL:
+                break
 
-			self.args.append(IRExpr._translate(a, irsb))
-		self.args = tuple(self.args)
+            self.args.append(IRExpr._translate(a, irsb))
+        self.args = tuple(self.args)
 
-	def __str__(self):
-		return "t%s = DIRTY %s %s ::: %s(%s)" % (self.tmp, self.guard, "TODO(effects)", self.cee, ','.join(str(a) for a in self.args))
+    def __str__(self):
+        return "t%s = DIRTY %s %s ::: %s(%s)" % (
+        self.tmp, self.guard, "TODO(effects)", self.cee, ','.join(str(a) for a in self.args))
 
-	@property
-	def child_expressions(self):
-		expressions = sum((a.child_expressions for a in self.args), [ ])
-		expressions.extend(self.args)
-		expressions.append(self.guard)
-		expressions.extend(self.guard.child_expressions)
-		return expressions
+    @property
+    def child_expressions(self):
+        expressions = sum((a.child_expressions for a in self.args), [])
+        expressions.extend(self.args)
+        expressions.append(self.guard)
+        expressions.extend(self.guard.child_expressions)
+        return expressions
+
 
 class Exit(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
-		self.guard = IRExpr._translate(c_stmt.Ist.Exit.guard, irsb)
-		self.dst = IRConst._translate(c_stmt.Ist.Exit.dst)
-		self.offsIP = c_stmt.Ist.Exit.offsIP
-		self.jk = ints_to_enums[c_stmt.Ist.Exit.jk]
+    """
+    A conditional exit from the middle of an IRSB.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
+        self.guard = IRExpr._translate(c_stmt.Ist.Exit.guard, irsb)
+        self.dst = IRConst._translate(c_stmt.Ist.Exit.dst)
+        self.offsIP = c_stmt.Ist.Exit.offsIP
+        self.jk = ints_to_enums[c_stmt.Ist.Exit.jk]
 
-	@property
-	def jumpkind(self):
-		return self.jk
+    @property
+    def jumpkind(self):
+        return self.jk
 
-	def __str__(self):
-		return "if (%s) { PUT(%s) = %s; %s }" % (self.guard, self.arch.translate_register_name(self.offsIP), hex(self.dst.value), self.jumpkind)
+    def __str__(self):
+        return "if (%s) { PUT(%s) = %s; %s }" % (
+        self.guard, self.arch.translate_register_name(self.offsIP), hex(self.dst.value), self.jumpkind)
 
-        @property
-        def child_expressions(self):
-                return [self.guard, self.dst] + self.guard.child_expressions
+    @property
+    def child_expressions(self):
+        return [self.guard, self.dst] + self.guard.child_expressions
+
 
 class LoadG(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
+    """
+    A guarded load.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
 
-		self.addr = IRExpr._translate(c_stmt.Ist.LoadG.details.addr, irsb)
-		self.alt = IRExpr._translate(c_stmt.Ist.LoadG.details.alt, irsb)
-		self.guard = IRExpr._translate(c_stmt.Ist.LoadG.details.guard, irsb)
-		self.dst = c_stmt.Ist.LoadG.details.dst
-		self.cvt = ints_to_enums[c_stmt.Ist.LoadG.details.cvt]
+        self.addr = IRExpr._translate(c_stmt.Ist.LoadG.details.addr, irsb)
+        self.alt = IRExpr._translate(c_stmt.Ist.LoadG.details.alt, irsb)
+        self.guard = IRExpr._translate(c_stmt.Ist.LoadG.details.guard, irsb)
+        self.dst = c_stmt.Ist.LoadG.details.dst
+        self.cvt = ints_to_enums[c_stmt.Ist.LoadG.details.cvt]
 
-		self.end = ints_to_enums[c_stmt.Ist.LoadG.details.end]
+        self.end = ints_to_enums[c_stmt.Ist.LoadG.details.end]
 
-		type_in = ffi.new('IRType *')
-		type_out = ffi.new('IRType *')
-		pvc.typeOfIRLoadGOp(c_stmt.Ist.LoadG.details.cvt, type_out, type_in)
-		type_in = ffi.cast('int *', type_in)[0]
-		type_out = ffi.cast('int *', type_out)[0]
-		self.cvt_types = (ints_to_enums[type_in], ints_to_enums[type_out])
+        type_in = ffi.new('IRType *')
+        type_out = ffi.new('IRType *')
+        pvc.typeOfIRLoadGOp(c_stmt.Ist.LoadG.details.cvt, type_out, type_in)
+        type_in = ffi.cast('int *', type_in)[0]
+        type_out = ffi.cast('int *', type_out)[0]
+        self.cvt_types = (ints_to_enums[type_in], ints_to_enums[type_out])
 
-	@property
-	def endness(self):
-		return self.end
+    @property
+    def endness(self):
+        return self.end
 
-	def __str__(self):
-		return "t%d = if (%s) %s(LD%s(%s)) else %s" % (self.dst, self.guard, self.cvt, self.end[-2:].lower(), self.addr, self.alt)
+    def __str__(self):
+        return "t%d = if (%s) %s(LD%s(%s)) else %s" % (
+        self.dst, self.guard, self.cvt, self.end[-2:].lower(), self.addr, self.alt)
+
 
 class StoreG(IRStmt):
-	def __init__(self, c_stmt, irsb):
-		IRStmt.__init__(self, c_stmt, irsb)
+    """
+    A guarded store.
+    """
+    def __init__(self, c_stmt, irsb):
+        IRStmt.__init__(self, c_stmt, irsb)
 
-		self.addr = IRExpr._translate(c_stmt.Ist.StoreG.details.addr, irsb)
-		self.data = IRExpr._translate(c_stmt.Ist.StoreG.details.data, irsb)
-		self.guard = IRExpr._translate(c_stmt.Ist.StoreG.details.guard, irsb)
-		self.end = ints_to_enums[c_stmt.Ist.StoreG.details.end]
+        self.addr = IRExpr._translate(c_stmt.Ist.StoreG.details.addr, irsb)
+        self.data = IRExpr._translate(c_stmt.Ist.StoreG.details.data, irsb)
+        self.guard = IRExpr._translate(c_stmt.Ist.StoreG.details.guard, irsb)
+        self.end = ints_to_enums[c_stmt.Ist.StoreG.details.end]
 
-	@property
-	def endness(self):
-		return self.end
+    @property
+    def endness(self):
+        return self.end
 
-	def __str__(self):
-		return "if (%s) ST%s(%s) = %s" % (self.guard, self.end[-2:].lower(), self.addr, self.data)
+    def __str__(self):
+        return "if (%s) ST%s(%s) = %s" % (self.guard, self.end[-2:].lower(), self.addr, self.data)
+
 
 from ..IRExpr import IRExpr
 from ..IRConst import IRConst
 from .. import IRRegArray, ints_to_enums, enums_to_ints, IRCallee, ffi, pvc, PyVEXError
 
 _tag_to_class = {
-	enums_to_ints['Ist_NoOp']: NoOp,
-	enums_to_ints['Ist_IMark']: IMark,
-	enums_to_ints['Ist_AbiHint']: AbiHint,
-	enums_to_ints['Ist_Put']: Put,
-	enums_to_ints['Ist_PutI']: PutI,
-	enums_to_ints['Ist_WrTmp']: WrTmp,
-	enums_to_ints['Ist_Store']: Store,
-	enums_to_ints['Ist_LoadG']: LoadG,
-	enums_to_ints['Ist_StoreG']: StoreG,
-	enums_to_ints['Ist_CAS']: CAS,
-	enums_to_ints['Ist_LLSC']: LLSC,
-	enums_to_ints['Ist_Dirty']: Dirty,
-	enums_to_ints['Ist_MBE']: MBE,
-	enums_to_ints['Ist_Exit']: Exit,
+    enums_to_ints['Ist_NoOp']: NoOp,
+    enums_to_ints['Ist_IMark']: IMark,
+    enums_to_ints['Ist_AbiHint']: AbiHint,
+    enums_to_ints['Ist_Put']: Put,
+    enums_to_ints['Ist_PutI']: PutI,
+    enums_to_ints['Ist_WrTmp']: WrTmp,
+    enums_to_ints['Ist_Store']: Store,
+    enums_to_ints['Ist_LoadG']: LoadG,
+    enums_to_ints['Ist_StoreG']: StoreG,
+    enums_to_ints['Ist_CAS']: CAS,
+    enums_to_ints['Ist_LLSC']: LLSC,
+    enums_to_ints['Ist_Dirty']: Dirty,
+    enums_to_ints['Ist_MBE']: MBE,
+    enums_to_ints['Ist_Exit']: Exit,
 }

--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -1,4 +1,8 @@
+"""
+Python bindings for Valgrind's VEX IR.
+"""
 import collections
+
 _counts = collections.Counter()
 
 import os
@@ -6,6 +10,7 @@ import sys
 
 # the lock
 import threading
+
 _libvex_lock = threading.Lock()
 
 if sys.platform == 'darwin':
@@ -13,8 +18,8 @@ if sys.platform == 'darwin':
 else:
     library_file = "pyvex_static.so"
 
-
-_pyvex_paths = [ os.path.join(os.path.dirname(__file__), '..', 'pyvex_c', library_file), os.path.join(sys.prefix, 'lib', library_file) ]
+_pyvex_paths = [os.path.join(os.path.dirname(__file__), '..', 'pyvex_c', library_file),
+                os.path.join(sys.prefix, 'lib', library_file)]
 
 _sigh = os.path.abspath(__file__)
 _prev_sigh = '$'
@@ -33,15 +38,17 @@ else:
 # Heeeere's pyvex!
 #
 import cffi
+
 ffi = cffi.FFI()
 from . import vex_ffi
+
 ffi.cdef(vex_ffi.ffi_str)
-pvc = ffi.dlopen(pyvex_path) #pylint:disable=undefined-loop-variable
+pvc = ffi.dlopen(pyvex_path)  # pylint:disable=undefined-loop-variable
 pvc.vex_init()
-dir(pvc) # lookup all the definitions (wtf)
-enums_to_ints = { _:getattr(pvc,_) for _ in dir(pvc) if hasattr(pvc,_) and isinstance(getattr(pvc,_), int) }
-ints_to_enums = { getattr(pvc,_):_ for _ in dir(pvc) if hasattr(pvc,_) and isinstance(getattr(pvc,_), int) }
-enum_IROp_fromstr = { _:enums_to_ints[_] for _ in enums_to_ints if _.startswith('Iop_') }
+dir(pvc)  # lookup all the definitions (wtf)
+enums_to_ints = {_: getattr(pvc, _) for _ in dir(pvc) if hasattr(pvc, _) and isinstance(getattr(pvc, _), int)}
+ints_to_enums = {getattr(pvc, _): _ for _ in dir(pvc) if hasattr(pvc, _) and isinstance(getattr(pvc, _), int)}
+enum_IROp_fromstr = {_: enums_to_ints[_] for _ in enums_to_ints if _.startswith('Iop_')}
 type_sizes = {
     'Ity_INVALID': None,
     'Ity_I1': 1,
@@ -50,30 +57,39 @@ type_sizes = {
     'Ity_I32': 32,
     'Ity_I64': 64,
     'Ity_I128': 128,
-    'Ity_F16':  16,
-    'Ity_F32':  32,
-    'Ity_F64':  64,
+    'Ity_F16': 16,
+    'Ity_F32': 32,
+    'Ity_F64': 64,
     'Ity_F128': 128,
-    'Ity_D32':  32,
-    'Ity_D64':  64,
+    'Ity_D32': 32,
+    'Ity_D64': 64,
     'Ity_D128': 128,
     'Ity_V128': 128,
     'Ity_V256': 256
 }
 
+
 def set_iropt_level(lvl):
     pvc.vex_control.iropt_level = lvl
+
 
 def _get_op_type(op):
     irsb = pvc.emptyIRSB()
     t = pvc.newIRTemp(irsb.tyenv, pvc.Ity_I8)
     e = pvc.IRExpr_Unop(enums_to_ints[op], pvc.IRExpr_RdTmp(t))
     return ints_to_enums[pvc.typeOfIRExpr(irsb.tyenv, e)]
-_op_types = { _:_get_op_type(_) for _ in enums_to_ints if _.startswith('Iop_') and _ != 'Iop_INVALID' and _ != 'Iop_LAST' }
+
+
+_op_types = {_: _get_op_type(_) for _ in enums_to_ints if
+             _.startswith('Iop_') and _ != 'Iop_INVALID' and _ != 'Iop_LAST'}
+
+
 def typeOfIROp(op): return _op_types[op]
+
 
 def vex_endness_from_string(endness_str):
     return getattr(pvc, endness_str)
+
 
 def default_vex_archinfo():
     return {
@@ -93,22 +109,35 @@ def default_vex_archinfo():
         'x86_cr0': 0xffffffff
     }
 
+
 class VEXObject(object):
+    """
+    The base class for Vex types.
+    """
     pass
-    #def __init__(self):
+    # def __init__(self):
     #   print "CREATING:",type(self)
     #   _counts[type(self)] += 1
 
-    #def __del__(self):
+    # def __del__(self):
     #   print "DELETING:",type(self)
     #   _counts[type(self)] -= 1
 
+
 class PyVEXError(Exception): pass
+
 
 # various objects
 _bytes = bytes
+
+
 class IRSB(VEXObject):
-    def __init__(self, bytes, mem_addr, arch, num_inst=None, num_bytes=None, bytes_offset=0, traceflags=0): #pylint:disable=redefined-builtin
+    """
+    IRSB stands for *Intermediate Representation Super Block*. An IRSB in VEX is a single-entry, multiple-exit code
+    block.
+    """
+    def __init__(self, bytes, mem_addr, arch, num_inst=None, num_bytes=None, bytes_offset=0,
+                 traceflags=0):  # pylint:disable=redefined-builtin
         try:
             _libvex_lock.acquire()
 
@@ -116,7 +145,7 @@ class IRSB(VEXObject):
 
             if isinstance(bytes, (str, _bytes)):
                 num_bytes = len(bytes) if num_bytes is None else num_bytes
-                c_bytes = ffi.new('char [%d]' % (num_bytes + 8), bytes + '\0'*8)
+                c_bytes = ffi.new('char [%d]' % (num_bytes + 8), bytes + '\0' * 8)
             else:
                 if not num_bytes:
                     raise PyVEXError("C-backed bytes must have the length specified by num_bytes")
@@ -133,7 +162,8 @@ class IRSB(VEXObject):
             if num_inst is not None:
                 c_irsb = pvc.vex_block_inst(vex_arch, arch.vex_archinfo, c_bytes + bytes_offset, mem_addr, num_inst)
             else:
-                c_irsb = pvc.vex_block_bytes(vex_arch, arch.vex_archinfo, c_bytes + bytes_offset, mem_addr, num_bytes, 1)
+                c_irsb = pvc.vex_block_bytes(vex_arch, arch.vex_archinfo, c_bytes + bytes_offset, mem_addr, num_bytes,
+                                             1)
 
             if c_irsb == ffi.NULL:
                 raise PyVEXError(ffi.string(pvc.last_error) if pvc.last_error != ffi.NULL else "unknown error")
@@ -143,7 +173,7 @@ class IRSB(VEXObject):
 
             self.c_irsb = c_irsb
             self.arch = arch
-            self.statements = [ IRStmt.IRStmt._translate(c_irsb.stmts[i], self) for i in range(c_irsb.stmts_used) ]
+            self.statements = [IRStmt.IRStmt._translate(c_irsb.stmts[i], self) for i in range(c_irsb.stmts_used)]
             self.next = IRExpr.IRExpr._translate(c_irsb.next, self)
             self.tyenv = IRTypeEnv(c_irsb.tyenv)
             self.offsIP = c_irsb.offsIP
@@ -161,22 +191,23 @@ class IRSB(VEXObject):
         print self._pp_str()
 
     def _pp_str(self):
-        sa = [ ]
+        sa = []
         sa.append("IRSB {")
         sa.append("   %s" % self.tyenv)
         sa.append("")
-        for i,s in enumerate(self.statements):
-            sa.append("   %02d | %s" % (i,s))
-        sa.append("   NEXT: PUT(%s) = %s; %s" % (self.arch.translate_register_name(self.offsIP), self.next, self.jumpkind))
+        for i, s in enumerate(self.statements):
+            sa.append("   %02d | %s" % (i, s))
+        sa.append(
+            "   NEXT: PUT(%s) = %s; %s" % (self.arch.translate_register_name(self.offsIP), self.next, self.jumpkind))
         sa.append("}")
         return '\n'.join(sa)
 
     @property
     def expressions(self):
-        '''
+        """
         All expressions contained in the IRSB.
-        '''
-        expressions = [ ]
+        """
+        expressions = []
         for s in self.statements:
             expressions.extend(s.expressions)
         expressions.append(self.next)
@@ -184,18 +215,18 @@ class IRSB(VEXObject):
 
     @property
     def instructions(self):
-        return len([ s.addr for s in self.statements if isinstance(s, IRStmt.IMark) ])
+        return len([s.addr for s in self.statements if isinstance(s, IRStmt.IMark)])
 
     @property
     def size(self):
-        return sum([ s.len for s in self.statements if isinstance(s, IRStmt.IMark) ])
+        return sum([s.len for s in self.statements if isinstance(s, IRStmt.IMark)])
 
     @property
     def operations(self):
-        '''
+        """
         All operations done by the IRSB.
-        '''
-        ops = [ ]
+        """
+        ops = []
         for e in self.expressions:
             if hasattr(e, 'op'):
                 ops.append(e.op)
@@ -203,23 +234,24 @@ class IRSB(VEXObject):
 
     @property
     def all_constants(self):
-        '''
+        """
         Returns all constants (including incrementing of the program counter).
-        '''
-        return sum((e.constants for e in self.expressions), [ ])
+        """
+        return sum((e.constants for e in self.expressions), [])
 
     @property
     def constants(self):
-        '''
+        """
         The constants (excluding updates of the program counter) in the IRSB.
-        '''
-        return sum((s.constants for s in self.statements if not (isinstance(s, IRStmt.Put) and s.offset == self.offsIP)), [ ])
+        """
+        return sum(
+            (s.constants for s in self.statements if not (isinstance(s, IRStmt.Put) and s.offset == self.offsIP)), [])
 
     @property
     def constant_jump_targets(self):
-        '''
+        """
         The static jump targets of the basic block.
-        '''
+        """
         exits = set()
         for s in self.statements:
             if isinstance(s, IRStmt.Exit):
@@ -232,9 +264,9 @@ class IRSB(VEXObject):
         return exits
 
     def _get_defaultexit_target(self):
-        '''
+        """
         Retrieves the default exit target, if it is constant.
-        '''
+        """
         if isinstance(self.next, IRExpr.Const):
             return self.next.con.value
 
@@ -268,16 +300,24 @@ class IRSB(VEXObject):
         target = self._get_defaultexit_target()
         return target is not None
 
+
 class IRTypeEnv(VEXObject):
+    """
+    An IR type environment.
+    """
     def __init__(self, tyenv):
         VEXObject.__init__(self)
-        self.types = [ ints_to_enums[tyenv.types[t]] for t in xrange(tyenv.types_used) ]
+        self.types = [ints_to_enums[tyenv.types[t]] for t in xrange(tyenv.types_used)]
         self.types_used = tyenv.types_used
 
     def __str__(self):
-        return ' '.join(("t%d:%s" % (i,t)) for i,t in enumerate(self.types))
+        return ' '.join(("t%d:%s" % (i, t)) for i, t in enumerate(self.types))
+
 
 class IRCallee(VEXObject):
+    """
+    Describes a helper function to call.
+    """
     def __init__(self, callee):
         VEXObject.__init__(self)
         self.regparms = callee.regparms
@@ -288,7 +328,12 @@ class IRCallee(VEXObject):
     def __str__(self):
         return self.name
 
+
 class IRRegArray(VEXObject):
+    """
+    A section of the guest state that we want te be able to index at run time, so as to be able to describe indexed or
+    rotating register files on the guest.
+    """
     def __init__(self, arr):
         VEXObject.__init__(self)
         self.base = arr.base
@@ -297,6 +342,7 @@ class IRRegArray(VEXObject):
 
     def __str__(self):
         return "%s:%sx%d" % (self.base, self.elemTy[4:], self.nElems)
+
 
 from . import IRConst
 from . import IRExpr


### PR DESCRIPTION
Mostly formatting of docstrings.  I also added short definitions from the Vex documentation for the statements and expressions as a docstring is needed for classes to show up in documentation generated by Sphinx.  

IRStmt/__init__.py was reformatted as it used tabs for indentation.