### PR TITLE
IR component creation in Python

### DIFF
--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -82,8 +82,8 @@ class IRSB(VEXObject):
             self.c_irsb = c_irsb
             self.arch = arch
             self.tyenv = IRTypeEnv(c_irsb.tyenv)
-            self.statements = [stmt.IRStmt._translate(c_irsb.stmts[i], self) for i in xrange(c_irsb.stmts_used)]
-            self.next = expr.IRExpr._translate(c_irsb.next, self)
+            self.statements = [stmt.IRStmt._translate(c_irsb.stmts[i]) for i in xrange(c_irsb.stmts_used)]
+            self.next = expr.IRExpr._translate(c_irsb.next)
             self.offsIP = c_irsb.offsIP
             self.stmts_used = c_irsb.stmts_used
             self.jumpkind = ints_to_enums[c_irsb.jumpkind]

--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -112,7 +112,14 @@ class IRSB(VEXObject):
         sa.append("   %s" % self.tyenv)
         sa.append("")
         for i, s in enumerate(self.statements):
-            sa.append("   %02d | %s" % (i, s))
+            stmt_str = ''
+            if isinstance(s, stmt.Put):
+                stmt_str = s.__str__(reg_name=self.arch.translate_register_name(s.offset, s.data.result_size(self.tyenv)/8))
+            elif isinstance(s, stmt.WrTmp) and isinstance(s.data, expr.Get):
+                stmt_str = s.__str__(reg_name=self.arch.translate_register_name(s.data.offset, s.data.result_size(self.tyenv)/8))
+            else:
+                stmt_str = s.__str__()
+            sa.append("   %02d | %s" % (i, stmt_str))
         sa.append(
             "   NEXT: PUT(%s) = %s; %s" % (self.arch.translate_register_name(self.offsIP), self.next, self.jumpkind))
         sa.append("}")

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -6,10 +6,10 @@ class IRConst(VEXObject):
     __slots__ = ['tag', 'value']
 
     type = None
+    tag = None
 
-    def __init__(self, c_expr):
+    def __init__(self):
         VEXObject.__init__(self)
-        self.tag = ints_to_enums[c_expr.tag]
 
     def pp(self):
         print self.__str__()
@@ -23,122 +23,177 @@ class IRConst(VEXObject):
         if c_expr[0] == ffi.NULL:
             return None
 
-        tag = c_expr.tag
+        tag_int = c_expr.tag
 
         try:
-            return tag_to_class[tag](c_expr)
+            return tag_to_class[tag_int].from_c(c_expr)
         except KeyError:
-            raise PyVEXError('Unknown/unsupported IRExprTag %s\n' % ints_to_enums[tag])
+            raise PyVEXError('Unknown/unsupported IRExprTag %s\n' % ints_to_enums[tag_int])
 
 class U1(IRConst):
     type = 'Ity_I1'
-
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.U1
+    tag = 'Ico_U1'
+    
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "%d" % self.value
 
+    @staticmethod
+    def from_c(c_expr):
+        return U1(c_expr.Ico.U1)
+
 class U8(IRConst):
     type = 'Ity_I8'
-
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.U8
+    tag = 'Ico_U8'
+    
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "0x%02x" % self.value
 
+    @staticmethod
+    def from_c(c_expr):
+        return U8(c_expr.Ico.U8)
+
 class U16(IRConst):
     type = 'Ity_I16'
+    tag = 'Ico_U16'
 
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.U16
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "0x%04x" % self.value
 
+    @staticmethod
+    def from_c(c_expr):
+        return U16(c_expr.Ico.U16)
+
 class U32(IRConst):
     type = 'Ity_I32'
-
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.U32
+    tag = 'Ico_U32'
+    
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "0x%08x" % self.value
 
+    @staticmethod
+    def from_c(c_expr):
+        return U32(c_expr.Ico.U32)
+
 class U64(IRConst):
     type = 'Ity_I64'
+    tag = 'Ico_U64'
 
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.U64
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "0x%016x" % self.value
 
+    @staticmethod
+    def from_c(c_expr):
+        return U64(c_expr.Ico.U64)
+
 class F32(IRConst):
     type = 'Ity_F32'
-
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.F32
+    tag = 'Ico_F32'
+    
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "%f" % self.value
+
+    @staticmethod
+    def from_c(c_expr):
+        return F32(c_expr.Ico.F32)
 
 class F32i(IRConst):
     type = 'Ity_F32'
+    tag = 'Ico_F32i'
 
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.F32
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "%f" % self.value
+
+    @staticmethod
+    def from_c(c_expr):
+        return F32i(c_expr.Ico.F32)
 
 class F64(IRConst):
     type = 'Ity_F64'
+    tag = 'Ico_F64'
 
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.F64
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "%f" % self.value
+
+    @staticmethod
+    def from_c(c_expr):
+        return F64(c_expr.Ico.F64)
 
 class F64i(IRConst):
     type = 'Ity_F64'
+    tag = 'Ico_F64i'
 
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.F64
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "%f" % self.value
 
+    @staticmethod
+    def from_c(c_expr):
+        return F64i(c_expr.Ico.F64)
+
 class V128(IRConst):
     type = 'Ity_V128'
-
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.V128
+    tag = 'Ico_V128'
+    
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "%x" % self.value
+
+    @staticmethod
+    def from_c(c_expr):
+        return V128(c_expr.Ico.V128)
 
 class V256(IRConst):
     type = 'Ity_V256'
+    tag = 'Ico_V256'
 
-    def __init__(self, c_expr):
-        IRConst.__init__(self, c_expr)
-        self.value = c_expr.Ico.V256
+    def __init__(self, value):
+        IRConst.__init__(self)
+        self.value = value
 
     def __str__(self):
         return "%x" % self.value
+
+    @staticmethod
+    def from_c(c_expr):
+        return V256(c_expr.Ico.V256)
 
 from .enums import ints_to_enums, enums_to_ints, type_sizes
 from .errors import PyVEXError

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -19,16 +19,29 @@ class IRConst(VEXObject):
         return type_sizes[self.type]
 
     @staticmethod
-    def _translate(c_expr):
-        if c_expr[0] == ffi.NULL:
+    def _from_c(c_const):
+        if c_const[0] == ffi.NULL:
             return None
 
-        tag_int = c_expr.tag
+        tag_int = c_const.tag
 
         try:
-            return tag_to_class[tag_int].from_c(c_expr)
+            return tag_to_class[tag_int]._from_c(c_const)
         except KeyError:
-            raise PyVEXError('Unknown/unsupported IRExprTag %s\n' % ints_to_enums[tag_int])
+            raise PyVEXError('Unknown/unsupported IRConstTag %s\n' % ints_to_enums[tag_int])
+    _translate = _from_c
+
+    @staticmethod
+    def _to_c(const):
+        # libvex throws an exception when constructing a U1 with a value other than 0 or 1
+        if const.tag == 'Ico_U1' and not const.value in (0, 1):
+            raise PyVEXError('Invalid U1 value: %d' % const.value)
+        
+        try:
+            return tag_to_ctor[const.tag](const.value)
+        except KeyError:
+            raise PyVEXError('Unknown/unsupported IRConstTag %s]n' % const.tag)
+        
 
 class U1(IRConst):
     type = 'Ity_I1'
@@ -42,8 +55,8 @@ class U1(IRConst):
         return "%d" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return U1(c_expr.Ico.U1)
+    def _from_c(c_const):
+        return U1(c_const.Ico.U1)
 
 class U8(IRConst):
     type = 'Ity_I8'
@@ -57,8 +70,8 @@ class U8(IRConst):
         return "0x%02x" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return U8(c_expr.Ico.U8)
+    def _from_c(c_const):
+        return U8(c_const.Ico.U8)
 
 class U16(IRConst):
     type = 'Ity_I16'
@@ -72,8 +85,8 @@ class U16(IRConst):
         return "0x%04x" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return U16(c_expr.Ico.U16)
+    def _from_c(c_const):
+        return U16(c_const.Ico.U16)
 
 class U32(IRConst):
     type = 'Ity_I32'
@@ -87,8 +100,8 @@ class U32(IRConst):
         return "0x%08x" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return U32(c_expr.Ico.U32)
+    def _from_c(c_const):
+        return U32(c_const.Ico.U32)
 
 class U64(IRConst):
     type = 'Ity_I64'
@@ -102,8 +115,8 @@ class U64(IRConst):
         return "0x%016x" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return U64(c_expr.Ico.U64)
+    def _from_c(c_const):
+        return U64(c_const.Ico.U64)
 
 class F32(IRConst):
     type = 'Ity_F32'
@@ -117,8 +130,8 @@ class F32(IRConst):
         return "%f" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return F32(c_expr.Ico.F32)
+    def _from_c(c_const):
+        return F32(c_const.Ico.F32)
 
 class F32i(IRConst):
     type = 'Ity_F32'
@@ -132,8 +145,8 @@ class F32i(IRConst):
         return "%f" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return F32i(c_expr.Ico.F32)
+    def _from_c(c_const):
+        return F32i(c_const.Ico.F32)
 
 class F64(IRConst):
     type = 'Ity_F64'
@@ -147,8 +160,8 @@ class F64(IRConst):
         return "%f" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return F64(c_expr.Ico.F64)
+    def _from_c(c_const):
+        return F64(c_const.Ico.F64)
 
 class F64i(IRConst):
     type = 'Ity_F64'
@@ -162,8 +175,8 @@ class F64i(IRConst):
         return "%f" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return F64i(c_expr.Ico.F64)
+    def _from_c(c_const):
+        return F64i(c_const.Ico.F64)
 
 class V128(IRConst):
     type = 'Ity_V128'
@@ -177,8 +190,8 @@ class V128(IRConst):
         return "%x" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return V128(c_expr.Ico.V128)
+    def _from_c(c_const):
+        return V128(c_const.Ico.V128)
 
 class V256(IRConst):
     type = 'Ity_V256'
@@ -192,12 +205,12 @@ class V256(IRConst):
         return "%x" % self.value
 
     @staticmethod
-    def from_c(c_expr):
-        return V256(c_expr.Ico.V256)
+    def _from_c(c_const):
+        return V256(c_const.Ico.V256)
 
 from .enums import ints_to_enums, enums_to_ints, type_sizes
 from .errors import PyVEXError
-from . import ffi
+from . import ffi, pvc
 
 tag_to_class = {
     enums_to_ints['Ico_U1']: U1,
@@ -211,4 +224,18 @@ tag_to_class = {
     enums_to_ints['Ico_F64i']: F64i,
     enums_to_ints['Ico_V128']: V128,
     enums_to_ints['Ico_V256']: V256,
+}
+
+tag_to_ctor = {
+    'Ico_U1': pvc.IRConst_U1,
+    'Ico_U8': pvc.IRConst_U8,
+    'Ico_U16': pvc.IRConst_U16,
+    'Ico_U32': pvc.IRConst_U32,
+    'Ico_U64': pvc.IRConst_U64,
+    'Ico_F32': pvc.IRConst_F32,
+    'Ico_F32i': pvc.IRConst_F32i,
+    'Ico_F64': pvc.IRConst_F64,
+    'Ico_F64i': pvc.IRConst_F64i,
+    'Ico_V128': pvc.IRConst_V128,
+    'Ico_V256': pvc.IRConst_V256,
 }

--- a/pyvex/enums.py
+++ b/pyvex/enums.py
@@ -46,7 +46,7 @@ class IRCallee(VEXObject):
     def _to_c(callee):
         c_callee = pvc.mkIRCallee(callee.regparms,
                                   callee.name,
-                                  callee.addr)
+                                  ffi.cast("void *", callee.addr))
         c_callee.mcx_mask = callee.mcx_mask
         return c_callee
 

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -88,7 +88,7 @@ class VECRET(IRExpr):
     tag = 'Iex_VECRET'
     
     def __init__(self):
-        IRExpr.__init__(self, c_expr)
+        IRExpr.__init__(self)
 
     def __str__(self):
         return "VECRET"
@@ -154,7 +154,7 @@ class RdTmp(IRExpr):
     tag = 'Iex_RdTmp'
 
     def __init__(self, tmp):
-        IRExpr.__init__(self, c_expr)
+        IRExpr.__init__(self)
         self.tmp = tmp
 
     def __str__(self):
@@ -174,14 +174,14 @@ class Get(IRExpr):
     tag = 'Iex_Get'
     
     def __init__(self, offset, ty):
-        IRExpr.__init__(self, c_expr)
+        IRExpr.__init__(self)
         self.offset = offset
         self.ty = ty
 
     @property
     def type(self):
         return self.ty
-
+    
     def __str__(self):
         return "GET:%s(%s)" % (self.ty[4:], self.arch.translate_register_name(self.offset, self.result_size/8))
 
@@ -278,10 +278,10 @@ class Binop(IRExpr):
 
     @staticmethod
     def from_c(c_expr):
-        return Binop(ints_to_enums[c_expr.Iex.Binop.details.op],
+        return Binop(ints_to_enums[c_expr.Iex.Binop.op],
                      [IRExpr._translate(arg)
-                      for arg in [c_expr.Iex.Binop.details.arg1,
-                                  c_expr.Iex.Binop.details.arg2]])
+                      for arg in [c_expr.Iex.Binop.arg1,
+                                  c_expr.Iex.Binop.arg2]])
 
 class Unop(IRExpr):
     """
@@ -296,13 +296,6 @@ class Unop(IRExpr):
         self.op = op
         self.args = args
     
-    def __init__(self, c_expr, irsb):
-        IRExpr.__init__(self, c_expr, irsb)
-        self.op = ints_to_enums[c_expr.Iex.Unop.op]
-        self.args = (
-            IRExpr._translate(c_expr.Iex.Unop.arg, irsb),
-        )
-
     def __str__(self):
         return "%s(%s)" % (self.op[4:], ','.join(str(a) for a in self.args))
 
@@ -346,7 +339,7 @@ class Load(IRExpr):
     @staticmethod
     def from_c(c_expr):
         return Load(ints_to_enums[c_expr.Iex.Load.end],
-                    ints_to_enums[c_expr.Iex.Load.ty]
+                    ints_to_enums[c_expr.Iex.Load.ty],
                     IRExpr._translate(c_expr.Iex.Load.addr))
 
 class Const(IRExpr):

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -504,6 +504,13 @@ class CCall(IRExpr):
                      IRCallee._from_c(c_expr.Iex.CCall.cee),
                      tuple(args))
 
+    @staticmethod
+    def _to_c(expr):
+        args = [IRExpr._to_c(arg) for arg in expr.args]
+        return pvc.IRExpr_CCall(IRCallee._to_c(expr.cee),
+                                enums_to_ints[expr.retty],
+                                mkIRExprVec[len(args)](*args))
+
 from .block import IRTypeEnv
 from .const import IRConst
 from .enums import IRCallee, IRRegArray, enums_to_ints, ints_to_enums, type_sizes
@@ -526,3 +533,15 @@ tag_to_class = {
     enums_to_ints['Iex_BBPTR']: BBPTR,
     enums_to_ints['Iex_VECRET']: VECRET,
 }
+
+mkIRExprVec = [
+    pvc.mkIRExprVec_0,
+    pvc.mkIRExprVec_1,
+    pvc.mkIRExprVec_2,
+    pvc.mkIRExprVec_3,
+    pvc.mkIRExprVec_4,
+    pvc.mkIRExprVec_5,
+    pvc.mkIRExprVec_6,
+    pvc.mkIRExprVec_7,
+    pvc.mkIRExprVec_8
+]


### PR DESCRIPTION
Here's the final commit of changes to allow Python creation of IR components without converting from the corresponding C structs. The initial discussion is in issue #47.

I kept the correspondence of fields between the C structs and the Python classes 1:1. I.e., you can roundtrip a Python IR instance to C and back to Python and no information is lost. Previously, Python IR instances had `result_size` and `result_type` fields, those have been converted to methods that take a type environment parameter. I searched around and the only external code that refers to those fields was in simuvex. I made the changes in simuvex to support this here: https://github.com/mattrepl/simuvex/tree/use_irsb_tyenv

I also changed how printing of Put statements and Get expressions with architecture register names is done. It's a little ugly, but it prevents needing the Python IR instances needing a type environment to be instantiated. Note that the IR C structs do not get coupled with a type environment; so pyvex now more closely follows libvex. I don't see a problem with this, other than the hack to get nice register names when printing statements and expressions.

Have started updating the unit tests as well, to make sure nothing is broken from these changes. That'll come in a later commit. 