### PR TITLE
Fix for using clang on macOS

### DIFF
--- a/make_ffi.py
+++ b/make_ffi.py
@@ -62,24 +62,24 @@ def doit(vex_path):
     errs = []
     for cpp in cpplist:
         cmd = [cpp, '-I' + vex_path, os.path.join("pyvex_c", "pyvex.h")]
-        if cpp == 'cl':
+        if cpp in ('cl', 'clang', 'gcc', 'cc', 'clang++', 'g++'):
             cmd.append("-E")
         try:
             p = subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             header, stderr = p.communicate()
-            if p.returncode != 0 or stderr:
-                errs.append((" ".join(cmd), stderr))
+            if not header.strip() or p.returncode != 0:
+                errs.append((" ".join(cmd), p.returncode, stderr))
                 continue
             else:
                 break
         except OSError:
-            errs.append((" ".join(cmd), "does not exist"))
+            errs.append((" ".join(cmd), -1, "does not exist"))
             continue
     else:
         l.warning("failed commands:\n" +
-                  "\n".join("{} -- {}".format(*e) for e in errs))
+                  "\n".join("{} ({}) -- {}".format(*e) for e in errs))
         raise Exception("Couldn't process pyvex headers - set CPP env var")
     #header = vex_pp + pyvex_pp
 

--- a/make_ffi.py
+++ b/make_ffi.py
@@ -60,7 +60,7 @@ def doit(vex_path):
     if cpp:
         cpplist.insert(0, cpp)
     if platform.system() == 'Darwin':
-        cpplist.insert("clang")
+        cpplist.insert(0, "clang")
 
     errs = []
     for cpp in cpplist:

--- a/make_ffi.py
+++ b/make_ffi.py
@@ -3,6 +3,7 @@ import os
 import sys
 import cffi
 import subprocess
+import platform
 
 import logging
 l = logging.getLogger('cffier')
@@ -58,6 +59,8 @@ def doit(vex_path):
     cpp = os.getenv("CPP")
     if cpp:
         cpplist.insert(0, cpp)
+    if platform.system() == 'Darwin':
+        cpplist.insert("clang")
 
     errs = []
     for cpp in cpplist:

--- a/make_ffi.py
+++ b/make_ffi.py
@@ -72,8 +72,8 @@ def doit(vex_path):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             header, stderr = p.communicate()
-            if not header.strip() or p.returncode != 0:
-                errs.append((" ".join(cmd), p.returncode, stderr))
+            if p.returncode != 0 or stderr or not header:
+                errs.append((" ".join(cmd), stderr))
                 continue
             else:
                 break
@@ -82,8 +82,11 @@ def doit(vex_path):
             continue
     else:
         l.warning("failed commands:\n" +
-                  "\n".join("{} ({}) -- {}".format(*e) for e in errs))
-        raise Exception("Couldn't process pyvex headers - set CPP env var")
+                  "\n".join("{} -- {}".format(*e) for e in errs))
+        raise Exception("Couldn't process pyvex headers." +
+                "Please set CPP environmental variable to local path of \"cpp\"." +
+                "Note that \"cpp\" and \"g++\" are different."
+                )
     #header = vex_pp + pyvex_pp
 
     linesep = '\r\n' if '\r\n' in header else '\n'


### PR DESCRIPTION
Fix for angr/pyvex#56 and possibly angr/simuvex#96.

Reinstalling pyvex using this on my macOS machine seemed to work fine, but should test with other systems too.