### PR TITLE
Fix `cpplist.insert` on OSX

### DIFF
--- a/make_ffi.py
+++ b/make_ffi.py
@@ -60,7 +60,7 @@ def doit(vex_path):
     if cpp:
         cpplist.insert(0, cpp)
     if platform.system() == 'Darwin':
-        cpplist.insert("clang")
+        cpplist.insert(0, "clang")
 
     errs = []
     for cpp in cpplist:


### PR DESCRIPTION
Looks like this was fixed originally in [this commit](https://github.com/angr/pyvex/commit/c7a6ce143550dc0e3547f05e6c44e9bb6ff7f371#diff-880d547726be1f58bf8980866c662020) and reverted by [this commit from March 16](https://github.com/angr/pyvex/commit/fcc7057fc0b84598ba724b4ccbded6013ae8a3a8#diff-880d547726be1f58bf8980866c662020).
