### PR TITLE
Make it possible to pretty-print IRStmt outside a Block.

### DIFF
--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -252,7 +252,7 @@ class IRSB(VEXObject):
             elif isinstance(s, stmt.WrTmp) and isinstance(s.data, expr.Get):
                 stmt_str = s.__str__(reg_name=self.arch.translate_register_name(s.data.offset, s.data.result_size(self.tyenv)/8))
             elif isinstance(s, stmt.Exit):
-                stmt_str = s.__str__(reg_name=self.arch.translate_register_name(s.offsIP, self.arch.bits))
+                stmt_str = s.__str__(reg_name=self.arch.translate_register_name(s.offsIP, self.arch.bits / 8))
             else:
                 stmt_str = s.__str__()
             sa.append("   %02d | %s" % (i, stmt_str))


### PR DESCRIPTION
To print out register names instead of register offsets, you only need
to pass in arch and tyenv to `IRStmt.__str__()`. The old way (reg_name) is
preserved to keep backward compatibility.