### PR TITLE
Update pyvex.def, fix msvc noreturn directive

### DIFF
--- a/pyvex_c/pyvex.c
+++ b/pyvex_c/pyvex.c
@@ -53,7 +53,11 @@ jmp_buf jumpout;
 //
 //======================================================================
 
+#ifdef _MSC_VER
+__declspec(noreturn)
+#else
 __attribute__((noreturn))
+#endif
 static void failure_exit(void) {
 	longjmp(jumpout, 1);
 }

--- a/pyvex_c/pyvex.def
+++ b/pyvex_c/pyvex.def
@@ -1,12 +1,8 @@
 LIBRARY pyvex.dll
 
 EXPORTS
-  vex_block_bytes
-  vex_block_inst
   vex_control
   vex_init
-  enable_debug
-  last_error
   emptyIRTypeEnv
   emptyIRSB
   IRConst_U1

--- a/pyvex_c/pyvex.def
+++ b/pyvex_c/pyvex.def
@@ -3,6 +3,7 @@ LIBRARY pyvex.dll
 EXPORTS
   vex_control
   vex_init
+  vex_lift
   emptyIRTypeEnv
   emptyIRSB
   IRConst_U1

--- a/pyvex_c/pyvex.def
+++ b/pyvex_c/pyvex.def
@@ -31,6 +31,7 @@ EXPORTS
   IRExpr_Const
   IRExpr_ITE
   IRExpr_CCall
+  log_level
   mkIRCallee
   mkIRExprVec_0
   mkIRExprVec_1
@@ -42,6 +43,7 @@ EXPORTS
   mkIRExprVec_7
   mkIRExprVec_8
   mkIRRegArray
+  msg_buffer
   newIRTemp
   sizeofIRType
   typeOfIRExpr


### PR DESCRIPTION
Builds were broken again under VS2015 - this patch should fix the build, but also depends on a companion PR I'll be sending through to `vex` shortly.