### PR TITLE
Change ffi parsing algorithm

### DIFF
--- a/make_ffi.py
+++ b/make_ffi.py
@@ -44,18 +44,8 @@ def find_good_scan(questionable):
                 for i in range(failed_line, -1, -1):
                     if failed_reason in candidate[i]:
                         failed_line = i
-                print '------------------------------------'
-                print 'failed at %d, known_good: %d, questionable: %d' % (failed_line, len(known_good), len(questionable))
-                print '\n'.join(map(lambda x: '%3d| %s' % x, enumerate(candidate))[failed_line-4:failed_line+4])
-                print e
-                print '------------------------------------'
             elif 'unrecognized construct' in str(e):
                 failed_line = int(str(e).split()[1][:-1])-1
-                print '===================================='
-                print 'failed at %d, known_good: %d, questionable: %d' % (failed_line, len(known_good), len(questionable))
-                print '\n'.join(map(lambda x: '%3d| %s' % x, enumerate(candidate))[failed_line-4:failed_line+4])
-                print e
-                print '===================================='
             elif 'end of input' in str(e):
                 end_line -= 1
             else:
@@ -63,11 +53,6 @@ def find_good_scan(questionable):
         except cffi.FFIError as e:
             if str(e).count(':') >= 2:
                 failed_line = int(str(e).split('\n')[0].split(':')[1])-1
-                print '************************************'
-                print 'failed at %d, known_good: %d, questionable: %d' % (failed_line, len(known_good), len(questionable))
-                print '\n'.join(map(lambda x: '%3d| %s' % x, enumerate(candidate))[failed_line-4:failed_line+4])
-                print e
-                print '************************************'
             else:
                 raise Exception("Unknown error")
 


### PR DESCRIPTION
This commit tries to fix issue #78

## Changes
* Remove unnecessary `find_good_bsearch` function
* Change the code format to fit PEP 8, except the line length rule
* Improve ffi parsing speed by changing the parsing algorithm

## TODO
New algorithm adds extra `Int r = (x == 0) ? ((Bool)0) : ((Bool)1);` line to `vex_ffi.py`. The line itself is a valid Python FFI definition, but it is in a function body and should be removed from the result.