### PR TITLE
Gymrat: Extend pyvex to support non-libvex lifters in a human-friendly way

### DIFF
--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -39,7 +39,7 @@ pvc = _find_c_lib()
 from .enums import *
 from .block import *
 from . import stmt, expr, const
-from .expr import op_type
+from .expr import get_op_retty
 
 # aliases....
 IRStmt = stmt

--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -39,6 +39,7 @@ pvc = _find_c_lib()
 from .enums import *
 from .block import *
 from . import stmt, expr, const
+from .expr import op_type
 
 # aliases....
 IRStmt = stmt

--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -40,6 +40,7 @@ from .enums import *
 from .block import *
 from . import stmt, expr, const
 from .expr import get_op_retty
+from .const import tag_to_const_class
 
 # aliases....
 IRStmt = stmt

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -118,6 +118,7 @@ class U32(IRConst):
 class U64(IRConst):
     type = 'Ity_I64'
     tag = 'Ico_U64'
+    op_format = '64'
     c_constructor = pvc.IRConst_U64
 
     def __init__(self, value):

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -1,4 +1,8 @@
-from . import VEXObject
+import re
+
+from . import VEXObject, ffi, pvc
+from .enums import get_enum_from_int
+from .errors import PyVEXError
 
 # IRConst hierarchy
 class IRConst(VEXObject):
@@ -7,6 +11,7 @@ class IRConst(VEXObject):
 
     type = None
     tag = None
+    c_constructor = None
 
     def __init__(self):
         VEXObject.__init__(self)
@@ -16,36 +21,37 @@ class IRConst(VEXObject):
 
     @property
     def size(self):
-        return type_sizes[self.type]
+        return get_type_size(self.type)
 
     @staticmethod
     def _from_c(c_const):
         if c_const[0] == ffi.NULL:
             return None
 
-        tag_int = c_const.tag
+        tag = get_enum_from_int(c_const.tag)
 
         try:
-            return tag_to_class[tag_int]._from_c(c_const)
+            return tag_to_const_class(tag)._from_c(c_const)
         except KeyError:
-            raise PyVEXError('Unknown/unsupported IRConstTag %s\n' % ints_to_enums[tag_int])
+            raise PyVEXError('Unknown/unsupported IRConstTag %s\n' % tag)
     _translate = _from_c
 
-    @staticmethod
-    def _to_c(const):
+    @classmethod
+    def _to_c(cls, const):
         # libvex throws an exception when constructing a U1 with a value other than 0 or 1
         if const.tag == 'Ico_U1' and not const.value in (0, 1):
             raise PyVEXError('Invalid U1 value: %d' % const.value)
 
         try:
-            return tag_to_ctor[enums_to_ints[const.tag]](const.value)
+            return cls.c_constructor(const.value)
         except KeyError:
             raise PyVEXError('Unknown/unsupported IRConstTag %s]n' % const.tag)
-
 
 class U1(IRConst):
     type = 'Ity_I1'
     tag = 'Ico_U1'
+    op_format = '1'
+    c_constructor = pvc.IRConst_U1
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -61,6 +67,8 @@ class U1(IRConst):
 class U8(IRConst):
     type = 'Ity_I8'
     tag = 'Ico_U8'
+    op_format = '8'
+    c_constructor = pvc.IRConst_U8
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -76,6 +84,8 @@ class U8(IRConst):
 class U16(IRConst):
     type = 'Ity_I16'
     tag = 'Ico_U16'
+    op_format = '16'
+    c_constructor = pvc.IRConst_U16
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -91,6 +101,8 @@ class U16(IRConst):
 class U32(IRConst):
     type = 'Ity_I32'
     tag = 'Ico_U32'
+    op_format = '32'
+    c_constructor = pvc.IRConst_U32
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -106,6 +118,7 @@ class U32(IRConst):
 class U64(IRConst):
     type = 'Ity_I64'
     tag = 'Ico_U64'
+    c_constructor = pvc.IRConst_U64
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -118,9 +131,33 @@ class U64(IRConst):
     def _from_c(c_const):
         return U64(c_const.Ico.U64)
 
+# Integer Type Imagination
+class_cache = { 1 : U1, 8 : U8, 16 : U16, 32 : U32, 64 : U64 }
+
+def vex_int_class(size):
+    try:
+        return class_cache[size]
+    except KeyError:
+        class VexInt(IRConst):
+            type = 'Ity_I%d' % size
+            tag = 'Ico_U%d' % size
+            op_format = str(size)
+
+            def __init__(self, value):
+                IRConst.__init__(self)
+                self.value = value
+
+            def __str__(self):
+                return '(0x%x :: %s)' % (self.value, self.type)
+        VexInt.__name__ = 'U%d' % size
+        class_cache[size] = VexInt
+        return VexInt
+
 class F32(IRConst):
     type = 'Ity_F32'
     tag = 'Ico_F32'
+    op_format = 'F32'
+    c_constructor = pvc.IRConst_F32
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -136,6 +173,8 @@ class F32(IRConst):
 class F32i(IRConst):
     type = 'Ity_F32'
     tag = 'Ico_F32i'
+    op_format = 'F32'
+    c_constructor = pvc.IRConst_F32i
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -151,6 +190,8 @@ class F32i(IRConst):
 class F64(IRConst):
     type = 'Ity_F64'
     tag = 'Ico_F64'
+    op_format = 'F64'
+    c_constructor = pvc.IRConst_F64
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -166,6 +207,8 @@ class F64(IRConst):
 class F64i(IRConst):
     type = 'Ity_F64'
     tag = 'Ico_F64i'
+    op_format = 'F64'
+    c_constructor = pvc.IRConst_F64i
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -181,6 +224,8 @@ class F64i(IRConst):
 class V128(IRConst):
     type = 'Ity_V128'
     tag = 'Ico_V128'
+    op_format = 'V128'
+    c_constructor = pvc.IRConst_V128
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -196,6 +241,8 @@ class V128(IRConst):
 class V256(IRConst):
     type = 'Ity_V256'
     tag = 'Ico_V256'
+    op_format = 'V256'
+    c_constructor = pvc.IRConst_V256
 
     def __init__(self, value):
         IRConst.__init__(self)
@@ -208,34 +255,46 @@ class V256(IRConst):
     def _from_c(c_const):
         return V256(c_const.Ico.V256)
 
-from .enums import ints_to_enums, enums_to_ints, type_sizes
-from .errors import PyVEXError
-from . import ffi, pvc
+predefined_types = [ U1, U8, U16, U32, U64, F32, F32i, F64, F64i, V128, V256 ]
+predefined_types_map = { c.type : c for c in predefined_types }
+predefined_classes_map = { c.tag : c for c in predefined_types }
 
-tag_to_class = {
-    enums_to_ints['Ico_U1']   : U1,
-    enums_to_ints['Ico_U8']   : U8,
-    enums_to_ints['Ico_U16']  : U16,
-    enums_to_ints['Ico_U32']  : U32,
-    enums_to_ints['Ico_U64']  : U64,
-    enums_to_ints['Ico_F32']  : F32,
-    enums_to_ints['Ico_F32i'] : F32i,
-    enums_to_ints['Ico_F64']  : F64,
-    enums_to_ints['Ico_F64i'] : F64i,
-    enums_to_ints['Ico_V128'] : V128,
-    enums_to_ints['Ico_V256'] : V256,
-}
+def is_int_ty(ty):
+    m = re.match(r'Ity_I\d+', ty)
+    return m is not None
 
-tag_to_ctor = {
-    enums_to_ints['Ico_U1']   : pvc.IRConst_U1,
-    enums_to_ints['Ico_U8']   : pvc.IRConst_U8,
-    enums_to_ints['Ico_U16']  : pvc.IRConst_U16,
-    enums_to_ints['Ico_U32']  : pvc.IRConst_U32,
-    enums_to_ints['Ico_U64']  : pvc.IRConst_U64,
-    enums_to_ints['Ico_F32']  : pvc.IRConst_F32,
-    enums_to_ints['Ico_F32i'] : pvc.IRConst_F32i,
-    enums_to_ints['Ico_F64']  : pvc.IRConst_F64,
-    enums_to_ints['Ico_F64i'] : pvc.IRConst_F64i,
-    enums_to_ints['Ico_V128'] : pvc.IRConst_V128,
-    enums_to_ints['Ico_V256'] : pvc.IRConst_V256,
-}
+def is_int_tag(tag):
+    m = re.match(r'Ico_U\d+', tag)
+    return m is not None
+
+def get_tag_size(tag):
+    m = re.match(r'Ico_[UFV](?P<size>\d+)i?', tag)
+    if m is None:
+        raise ValueError('Tag %s does not have size' % ty)
+    return int(m.group('size'))
+
+def get_type_size(ty):
+    m = re.match(r'Ity_[IFDV](?P<size>\d+)', ty)
+    if m is None:
+        raise ValueError('Type %s does not have size' % ty)
+    return int(m.group('size'))
+
+def ty_to_const_class(ty):
+    try:
+        return predefined_types_map[ty]
+    except KeyError:
+        if is_int_ty(ty):
+            size = get_type_size(ty)
+            return vex_int_class(size)
+        else:
+            raise ValueError('Type %s does not exist' % ty)
+
+def tag_to_const_class(tag):
+    try:
+        return predefined_classes_map[tag]
+    except KeyError:
+        if is_int_tag(tag):
+            size = get_tag_size(tag)
+            return vex_int_class(size)
+        else:
+            raise ValueError('Tag %s does not exist' % tag)

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -38,7 +38,7 @@ class IRConst(VEXObject):
             raise PyVEXError('Invalid U1 value: %d' % const.value)
 
         try:
-            return tag_to_ctor[const.tag](const.value)
+            return tag_to_ctor[enums_to_ints[const.tag]](const.value)
         except KeyError:
             raise PyVEXError('Unknown/unsupported IRConstTag %s]n' % const.tag)
 
@@ -213,29 +213,29 @@ from .errors import PyVEXError
 from . import ffi, pvc
 
 tag_to_class = {
-    enums_to_ints['Ico_U1']: U1,
-    enums_to_ints['Ico_U8']: U8,
-    enums_to_ints['Ico_U16']: U16,
-    enums_to_ints['Ico_U32']: U32,
-    enums_to_ints['Ico_U64']: U64,
-    enums_to_ints['Ico_F32']: F32,
-    enums_to_ints['Ico_F32i']: F32i,
-    enums_to_ints['Ico_F64']: F64,
-    enums_to_ints['Ico_F64i']: F64i,
-    enums_to_ints['Ico_V128']: V128,
-    enums_to_ints['Ico_V256']: V256,
+    enums_to_ints['Ico_U1']   : U1,
+    enums_to_ints['Ico_U8']   : U8,
+    enums_to_ints['Ico_U16']  : U16,
+    enums_to_ints['Ico_U32']  : U32,
+    enums_to_ints['Ico_U64']  : U64,
+    enums_to_ints['Ico_F32']  : F32,
+    enums_to_ints['Ico_F32i'] : F32i,
+    enums_to_ints['Ico_F64']  : F64,
+    enums_to_ints['Ico_F64i'] : F64i,
+    enums_to_ints['Ico_V128'] : V128,
+    enums_to_ints['Ico_V256'] : V256,
 }
 
 tag_to_ctor = {
-    'Ico_U1': pvc.IRConst_U1,
-    'Ico_U8': pvc.IRConst_U8,
-    'Ico_U16': pvc.IRConst_U16,
-    'Ico_U32': pvc.IRConst_U32,
-    'Ico_U64': pvc.IRConst_U64,
-    'Ico_F32': pvc.IRConst_F32,
-    'Ico_F32i': pvc.IRConst_F32i,
-    'Ico_F64': pvc.IRConst_F64,
-    'Ico_F64i': pvc.IRConst_F64i,
-    'Ico_V128': pvc.IRConst_V128,
-    'Ico_V256': pvc.IRConst_V256,
+    enums_to_ints['Ico_U1']   : pvc.IRConst_U1,
+    enums_to_ints['Ico_U8']   : pvc.IRConst_U8,
+    enums_to_ints['Ico_U16']  : pvc.IRConst_U16,
+    enums_to_ints['Ico_U32']  : pvc.IRConst_U32,
+    enums_to_ints['Ico_U64']  : pvc.IRConst_U64,
+    enums_to_ints['Ico_F32']  : pvc.IRConst_F32,
+    enums_to_ints['Ico_F32i'] : pvc.IRConst_F32i,
+    enums_to_ints['Ico_F64']  : pvc.IRConst_F64,
+    enums_to_ints['Ico_F64i'] : pvc.IRConst_F64i,
+    enums_to_ints['Ico_V128'] : pvc.IRConst_V128,
+    enums_to_ints['Ico_V256'] : pvc.IRConst_V256,
 }

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -741,7 +741,7 @@ def shift_signature(op):
 
 def cmp_signature(op):
     m = re.match(r'Iop_Cmp(EQ|NE)(?P<size>\d+)$', op)
-    m2 = re.match(r'Iop_Cmp(LT|LE)(?P<size>\d+)[SU]$', op)
+    m2 = re.match(r'Iop_Cmp(GT|GE|LT|LE)(?P<size>\d+)[SU]$', op)
     if (m is None) == (m2 is None):
         raise PyvexOpMatchException()
     mfound = m if m is not None else m2

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -685,35 +685,39 @@ def op_type(op):
         _op_type_cache[op] = out
         return out
 
+op_signatures = {}
 def op_arg_types(op):
-    res_ty = ffi.new('IRType *')
-    arg1_ty = ffi.new('IRType *')
-    arg2_ty = ffi.new('IRType *')
-    arg3_ty = ffi.new('IRType *')
-    arg4_ty = ffi.new('IRType *')
-    arg2_ty[0] = 0x1100
-    arg3_ty[0] = 0x1100
-    arg4_ty[0] = 0x1100
+    try:
+        return op_signatures[op]
+    except KeyError:
+        res_ty = ffi.new('IRType *')
+        arg1_ty = ffi.new('IRType *')
+        arg2_ty = ffi.new('IRType *')
+        arg3_ty = ffi.new('IRType *')
+        arg4_ty = ffi.new('IRType *')
+        arg2_ty[0] = 0x1100
+        arg3_ty[0] = 0x1100
+        arg4_ty[0] = 0x1100
 
-    pvc.typeOfPrimop(enums_to_ints[op], res_ty, arg1_ty, arg2_ty, arg3_ty, arg4_ty)
-    if arg2_ty[0] == 0x1100:
-        return (ints_to_enums[res_ty[0]],
-                (ints_to_enums[arg1_ty[0]],))
-    elif arg3_ty[0] == 0x1100:
-        return (ints_to_enums[res_ty[0]],
-                (ints_to_enums[arg1_ty[0]],
-                 ints_to_enums[arg2_ty[0]],))
-    elif arg4_ty[0] == 0x1100:
-        return (ints_to_enums[res_ty[0]],
-                (ints_to_enums[arg1_ty[0]],
-                 ints_to_enums[arg2_ty[0]],
-                 ints_to_enums[arg3_ty[0]],))
-    else:
-        return (ints_to_enums[res_ty[0]],
-                (ints_to_enums[arg1_ty[0]],
-                 ints_to_enums[arg2_ty[0]],
-                 ints_to_enums[arg3_ty[0]],
-                 ints_to_enums[arg4_ty[0]],))
+        pvc.typeOfPrimop(enums_to_ints[op], res_ty, arg1_ty, arg2_ty, arg3_ty, arg4_ty)
+        if arg2_ty[0] == 0x1100:
+            return (ints_to_enums[res_ty[0]],
+                    (ints_to_enums[arg1_ty[0]],))
+        elif arg3_ty[0] == 0x1100:
+            return (ints_to_enums[res_ty[0]],
+                    (ints_to_enums[arg1_ty[0]],
+                     ints_to_enums[arg2_ty[0]],))
+        elif arg4_ty[0] == 0x1100:
+            return (ints_to_enums[res_ty[0]],
+                    (ints_to_enums[arg1_ty[0]],
+                     ints_to_enums[arg2_ty[0]],
+                     ints_to_enums[arg3_ty[0]],))
+        else:
+            return (ints_to_enums[res_ty[0]],
+                    (ints_to_enums[arg1_ty[0]],
+                     ints_to_enums[arg2_ty[0]],
+                     ints_to_enums[arg3_ty[0]],
+                     ints_to_enums[arg4_ty[0]],))
 
 from .const import IRConst
 from .enums import IRCallee, IRRegArray, enums_to_ints, ints_to_enums, type_sizes

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -722,7 +722,7 @@ def unop_signature(op):
     return (size_type, (size_type,))
 
 def binop_signature(op):
-    m = re.match(r'Iop_(Add|Sub|Mul|Or|And|Div(S|U))(?P<size>\d+)$', op)
+    m = re.match(r'Iop_(Add|Sub|Mul|Xor|Or|And|Div(S|U))(?P<size>\d+)$', op)
     if m is None:
         raise PyvexOpMatchException()
     size = int(m.group('size'))

--- a/pyvex/lift/util/__init__.py
+++ b/pyvex/lift/util/__init__.py
@@ -1,0 +1,4 @@
+from .vex_helper import Type, JumpKind
+from .syntax_wrapper import VexValue
+from .instr_helper import ParseError, Instruction
+from .lifter_helper import GymratLifter, ParseError

--- a/pyvex/lift/util/instr_helper.py
+++ b/pyvex/lift/util/instr_helper.py
@@ -1,0 +1,280 @@
+from lifter_helper import ParseError
+from syntax_wrapper import VexValue
+from vex_helper import JumpKind, IRExpr
+
+import abc
+import string
+import bitstring
+import logging
+from angr.engines.vex import ccall
+
+l = logging.getLogger("instr")
+l.setLevel(logging.DEBUG)
+
+
+class Instruction:
+    """
+    Base class for an Instruction.
+    You should make a subclass of this for each instruction you want to lift.
+    These classes will contain the "semantics" of the instruction, that is, what it _does_, in terms of the VEX IR.
+
+    You may want to subclass this for your architecture, and add arch-specific handling
+    for parsing, argument resolution, etc, and have instructions subclass that instead.
+
+    The core parsing functionality is done via a "bit format".  Each instruction should be a subclass of Instruction,
+    and will be parsed by comparing bits in the provided bitstream to symbols in the bit_format member of the class.
+    Bit formats are strings of symbols, like those you'd find in an ISA document, such as "0010rrrrddddffmm"
+    0 or 1 specify hard-coded bits that must match for an instruction to match.
+    Any letters specify arguments, grouped by letter, which will be parsed and provided as bitstrings in the "data"
+    member of the class as a dictionary.
+    So, in our example, the bits 0010110101101001, applied to format string 0010rrrrddddffmm
+    will result in the following in self.data:
+    {'r': '1101',
+     'd': '0110',
+     'f': '10',
+     'm': '01'}
+
+    Implement compute_result to provide the "meat" of what your instruction does.
+     You can also implement it in your arch-specific subclass of Instruction, to handle things common to all
+     instructions, and provide instruction implementations elsewhere..
+
+    We provide the VexValue syntax wrapper to make expressing instruction semantics easy.
+    You first convert the bitstring arguments into VexValues using the provided convenience methods (self.get/put/load)
+    store/etc. This loads the register from the actual registers into a temporary value we can work with.
+    You can then write it back to a register when you're done.
+    For example, if you have the register in 'r', as above, you can make a VexValue like this:
+    r_vv = self.get(int(self.data['r'], 2), Type.int_32)
+    If you then had an instruction to increment r, you could simply:
+    return r_vv += 1
+    You could then write it back to the register like this:
+    self.put(r_vv, int(self.data['r', 2))
+
+    Note that most architectures have special flags that get set differently for each instruction, make sure to
+    implement those as well. (override set_flags() )
+
+    Override parse() to extend parsing; for example, in MSP430, this allows us to grab extra words from the bitstream
+    when extra immediate words are present.
+
+    All architectures are different enough that there's no magic recipe for how to write a lifter;
+    See the examples provided by gymrat for ideas of how to use this to build your own lifters quickly and easily.
+    """
+
+    data = None
+    irsb_c = None
+
+    def __init__(self, irsb_c, bitstrm, addr):
+        """
+        Create an instance of the instruction
+        :param irsb_c: The IRSBCustomizer to put VEX instructions into
+        :param bitstrm: The bitstream to decode instructions from
+        :param addr: The address of the instruction to be lifted, used only for jumps and branches
+        """
+        self.irsb_c = irsb_c
+        self.addr = addr
+        self.width = len(self.bin_format)
+        self.data = self.parse(bitstrm)
+
+    def __call__(self):
+        self.lift()
+
+    def mark_instruction_start(self):
+        # TODO: WARNING: VEX assumes 8-bit bytes here.
+        bytewidth = self.bitwidth / 8
+        self.irsb_c.imark(self.addr, bytewidth, bytewidth)
+
+    def fetch_operands(self):
+        """
+        Get the operands out of memory or registers
+        Return a tuple of operands for the instruction
+        :return:
+        """
+        return []
+
+    def lift(self):
+        """
+        THis is the main body of the "lifting" for the instruction.
+        This can/should be overriden to provide the general flow of how instructions in your arch work.
+        For example, in MSP430, this is:
+            1) Figure out what your operands are by parsing the addressing, and load them into temporary registers
+            2) Do the actual operation, and commit the result, if needed.
+            3) Compute the flags
+        :return:
+        """
+        # Always call this first!
+        self.mark_instruction_start()
+        # Then do the actual stuff.
+        inputs = self.fetch_operands()
+        retval = self.compute_result(*inputs)
+        if retval is not None:
+            inputs = tuple(list(inputs).append(retval))
+        self.compute_flags(*inputs)
+
+    @abc.abstractmethod
+    def compute_result(self, *args):
+        """
+        This is where the actual operation performed by your instruction, excluding the calculation of flags, should be
+        performed.  Return the VexValue of the "result" of the instruction, which may
+        be used to calculate the flags later.
+        For example, for a simple add, with arguments src and dst, you can simply write:
+            return src + dst:
+
+        :param args:
+        :return: A VexValue containing the "result" of the operation.
+        """
+        pass
+
+    def compute_flags(self, *args):
+        """
+        Most CPU architectures have "flags" that should be computed for many instructions.
+        Override this to specify how that happens.  One common pattern is to define this method to call specifi methods
+        to update each flag, which can then be overriden in the actual classes for each instruction.
+        :return: n/a
+        """
+        pass
+
+    def match_instruction(self, data, bitstrm):
+        """
+        Override this to extend the parsing functionality.
+        This is great for if your arch has instruction "formats" that have an opcode that has to match.
+        :param data:
+        :param bitstrm:
+        :return: data
+        """
+        return data
+
+    def parse(self, bitstrm):
+        beforebits = bitstrm.bitpos
+        numbits = len(self.bin_format)
+        if self.irsb_c.irsb.arch.memory_endness == 'Iend_LE':
+            # Get it out little endian.  I hate this.
+            instr_bits = bitstring.Bits(uint=bitstrm.peek("uintle:%d" % numbits), length=numbits).bin
+        else:
+            instr_bits = bitstrm.peek("bin:%d" % numbits)
+        data = {c : '' for c in self.bin_format if c in string.ascii_letters}
+        for c, b in zip(self.bin_format, instr_bits):
+            if c in '01':
+                if b != c:
+                    raise ParseError('Mismatch between format bit %c and instruction bit %c' % (c, b))
+            elif c in string.ascii_letters:
+                data[c] += b
+            else:
+                raise ValueError('Invalid bin_format character %c' % c)
+        # Hook here for extra matching functionality
+        if hasattr(self, 'match_instruction'):
+            # Should raise if it's not right
+            self.match_instruction(data, bitstrm)
+        # Use up the bits once we're sure it's right
+        self.rawbits = bitstrm.read('hex:%d' % numbits)
+        # Hook here for extra parsing functionality (e.g., trailers)
+        if hasattr(self, '_extra_parsing'):
+            data = self._extra_parsing(data, bitstrm)
+        afterbits = bitstrm.bitpos
+        self.bitwidth = afterbits - beforebits
+        return data
+
+    def disassemble(self):
+        """
+        Return the disassembly of this instruction, as a string.
+        Override this in subclasses.
+        :return: The address (self.addr), the instruction's name, and a list of its operands, as strings
+        """
+        return self.addr, 'UNK', [self.rawbits]
+
+    # These methods should be called in subclasses to do register and memory operations
+
+    def load(self, addr, ty):
+        """
+        Load a value from memory into a VEX temporary register.
+        :param addr: The VexValue containing the addr to load from.
+        :param ty: The Type of the resulting data
+        :return: a VexValue
+        """
+        rdt = self.irsb_c.load(addr.rdt, ty)
+        return VexValue(self.irsb_c, rdt)
+
+    def constant(self, val, ty):
+        """
+        Creates a constant as a VexValue
+        :param val: The value, as an integer
+        :param ty: The type of the resulting VexValue
+        :return: a VexValue
+        """
+        assert not (isinstance(val, VexValue) or isinstance(val, IRExpr))
+        rdt = self.irsb_c.mkconst(val, ty)
+        return VexValue(self.irsb_c, rdt)
+
+    def get(self, reg_num, ty):
+        """
+        Load a value from a machine register into a VEX temporary register.
+        All values must be loaded out of registers before they can be used with operations, etc
+        and stored back into them when the instruction is over.  See Put().
+
+        :param reg_num: Register number as an integer to get from
+        :param ty: The Type to use.
+        :return: A VexValue of the gotten value.
+        """
+        # TODO: Resolve strings like 'sr' or 'pc' into the right numbers using archinfo
+        rdt = self.irsb_c.rdreg(reg_num, ty)
+        return VexValue(self.irsb_c, rdt)
+
+    def put(self, val, reg):
+        """
+        Puts a value from a VEX temporary register into a machine register.
+        This is how the results of operations done to registers get committed to the machine's state.
+        :param val: The VexValue to store (Want to store a constant? See Constant() first)
+        :param reg: The integer register number to store into.
+        :return: None
+        """
+        # TODO: Resolve strings like 'sr' or 'pc' into the right numbers using archinfo
+        self.irsb_c.put(val.rdt, reg)
+
+    def store(self, val, addr):
+        """
+        Store a VexValue in memory at the specified loaction.
+        :param val: The VexValue of the value to store
+        :param addr: The VexValue of the address to store into
+        :return: None
+        """
+        # TODO: Resolve strings like 'sr' or 'pc' into the right numbers using archinfo
+        self.irsb_c.store(addr.rdt, val.rdt)
+
+    def jump(self, condition, to_addr, jumpkind=JumpKind.Boring):
+        """
+        Jump to a specified destination, under the specified condition.
+        Used for branches, jumps, calls, returns, etc.
+        :param condition: The VexValue representing the expression for the guard, or None for an unconditional jump
+        :param to_addr: The address to jump to.
+        :param jumpkind: The JumpKind to use.  See the VEX docs for what these are; you only need them for things
+        aren't normal jumps (e.g., calls, interrupts, program exits, etc etc)
+        :return: None
+        """
+        assert isinstance(to_addr, VexValue)
+        if not condition:
+            # This is the default exit.
+            self.irsb_c.irsb.jumpkind = jumpkind
+            self.irsb_c.irsb.next = to_addr.rdt
+        else:
+            # add another exit
+            self.irsb_c.add_exit(condition.rdt, to_addr.rdt.con, jumpkind, self.addr)
+            # and then set the default
+            self.irsb_c.irsb.jumpkind = jumpkind
+            self.irsb_c.irsb.next = self.constant(self.addr + (self.bitwidth / 8), to_addr.ty).rdt
+
+    def ccall(self, ret_type, func_obj, args):
+        """
+        Creates a CCall operation.
+        A CCall is a procedure that calculates a value at *runtime*, not at lift-time.
+        You can use these for flags, unresolvable jump targets, etc.
+        We caution you to avoid using them when at all possible though.
+
+        For an example of how to write and use a CCall, see gymrat/bf/lift_bf.py
+        :param ret_type: The return type of the CCall
+        :param func_obj: The function object to eventually call.
+        :param args: List of arguments to the function
+        :return: A VexValue of the result.
+        """
+        # HACK: FIXME: If you're reading this, I'm sorry. It's truly a crime against Python...
+        if not hasattr(ccall, func_obj.func_name):
+            setattr(ccall, func_obj.func_name, func_obj)
+        cc = self.irsb_c.op_ccall(ret_type, func_obj.func_name, args)
+        return VexValue(self.irsb_c, cc)

--- a/pyvex/lift/util/lifter_helper.py
+++ b/pyvex/lift/util/lifter_helper.py
@@ -1,0 +1,104 @@
+import struct
+import archinfo
+import pyvex
+from functools import wraps
+from pyvex.expr import *
+from pyvex.lift import Lifter, register
+from .vex_helper import *
+from syntax_wrapper import VexValue
+import logging
+import bitstring
+
+
+def is_empty(bitstrm):
+    try:
+        bitstrm.peek(1)
+        return False
+    except bitstring.ReadError:
+        return True
+
+
+class ParseError(Exception):
+    pass
+
+
+class GymratLifter(Lifter):
+    """
+    This is a base class for lifters that use Gymrat.
+    For most architectures, all you need to do is subclass this, and set the property "instructions"
+    to be a list of classes that define each instruction.
+    By default, a lifter will decode instructions by attempting to instantiate every class until one works.
+    This will use an IRSBCustomizer, which will, if it succeeds, add the appropriate VEX instructions to a pyvex IRSB.
+    pyvex, when lifting a block of code for this architecture, will call the method "lift", which will produce the IRSB
+    of the lifted code.
+    """
+    def __init__(self, irsb, data, max_inst, max_bytes, bytes_offset, opt_level=None,
+                    traceflags=None, allow_lookback=None):
+        super(GymratLifter, self).__init__(irsb, data, max_inst, max_bytes,
+                bytes_offset, opt_level, traceflags, allow_lookback)
+        self.logger = logging.getLogger('lifter')
+        self.logger.setLevel(logging.DEBUG)
+        if 'CData' in str(type(data)):
+            thedata = "".join([chr(data[x]) for x in range(max_bytes)])
+        else:
+            thedata = data
+        self.bitstrm = bitstring.ConstBitStream(bytes=thedata)
+
+    def lift(self, disassemble=False, dump_irsb=False):
+        try:
+            count = 0
+            disas = []
+            if not self.max_inst:
+                self.max_inst = 1000000
+            self.irsb.jumpkind = JumpKind.Invalid
+            irsb_c = IRSBCustomizer(self.irsb, self.irsb.arch)
+            addr = self.irsb._addr
+            pos = self.bitstrm.bitpos
+            while (count < self.max_inst
+                    and (self.bitstrm.bitpos + 7) / 8 < self.max_bytes
+                    and self.irsb.jumpkind == JumpKind.Invalid
+                    and not is_empty(self.bitstrm)):
+                # Try every instruction until one works
+                for possible_instr in self.instrs:
+                    try:
+                        instr = possible_instr(irsb_c, self.bitstrm, addr)
+                        break
+                    except ParseError:
+                        pass #self.logger.exception(repr(possible_instr))
+                    except Exception, e:
+                        self.logger.debug(e.message)
+                else:
+                    errorstr = 'Unknown instruction at bit position %d' % self.bitstrm.bitpos
+                    self.logger.critical(errorstr)
+                    self.logger.critical("Address: %#08x" % addr)
+                    raise Exception(errorstr)
+                if disassemble:
+                    disas.append(instr.disassemble())
+                else:
+                    instr()
+                # WARNING: We assume 8 bit bytes here.
+                addr += (self.bitstrm.bitpos - pos) / 8
+                pos = self.bitstrm.bitpos
+                count += 1
+            if dump_irsb:
+                self.irsb.pp()
+            if disassemble:
+                return disas
+            return self.irsb
+        except Exception, e:
+            self.errors = e.message
+            self.logger.exception("Error lifting block:")
+            raise e
+
+    def pp_disas(self, addr, name, args):
+        args_str = ",".join(str(a) for a in args)
+        return "%0#08x:\t%s %s" % (addr, name, args_str)
+
+    def error(self):
+        return self.errors
+
+    def disassemble(self):
+        return self.lift(disassemble=True)
+
+if __name__ == '__main__':
+    pass

--- a/pyvex/lift/util/syntax_wrapper.py
+++ b/pyvex/lift/util/syntax_wrapper.py
@@ -1,0 +1,253 @@
+
+import functools
+
+from .vex_helper import IRSBCustomizer, Type, JumpKind
+import pyvex
+from pyvex.expr import IRExpr, Const, RdTmp, Unop, Binop, Triop, Qop, Load, CCall, Get
+
+
+def checkparams(*fn, **options):
+    rhstype = options.pop('rhstype', None)
+    if options:
+        raise TypeError("unsupported keyword arguments: %s" %
+                        ",".join(options.keys()))
+
+    if fn:
+        def wrapper(self, *args, **kwargs):
+            irsb_cs = {a.irsb_c for a in list(args) + [self] if isinstance(a, VexValue)}  # pylint: disable=no-member
+            assert len(irsb_cs) == 1, 'All VexValues must belong to the same irsb_c'
+            args = list(args)
+            for arg in args:
+                if isinstance(arg, int):
+                    thetype = rhstype if rhstype else self.ty
+                    args[args.index(arg)] = VexValue.Constant(self.irsb_c, arg, thetype)
+            args = tuple(args)
+            return fn[0](self, *args, **kwargs)
+        return functools.update_wrapper(wrapper, fn[0])
+    else:
+        def decorator(fn):
+            def wrapper(self, *args, **kwargs):
+                irsb_cs = {a.irsb_c for a in list(args) + [self] if
+                           isinstance(a, VexValue)}  # pylint: disable=no-member
+                assert len(irsb_cs) == 1, 'All VexValues must belong to the same irsb_c'
+                args = list(args)
+                for arg in args:
+                    if isinstance(arg, int):
+                        thetype = rhstype if rhstype else self.ty
+                        args[args.index(arg)] = VexValue.Constant(self.irsb_c, arg, thetype)
+                args = tuple(args)
+                return fn(self, *args, **kwargs)
+            return functools.update_wrapper(wrapper, fn)
+        return decorator
+
+
+def vvifyresults(f):
+    @functools.wraps(f)
+    def decor(self, *args, **kwargs):
+        returned = f(self, *args, **kwargs)
+        assert isinstance(returned, RdTmp) or isinstance(returned, Const)
+        return VexValue(self.irsb_c, returned)
+    return decor
+
+
+class VexValue:
+    def __init__(self, irsb_c, rdt):
+        self.irsb_c = irsb_c
+        self.ty = self.irsb_c.get_type(rdt)
+        self.rdt = rdt
+        self.width = pyvex.get_type_size(self.ty)
+        self.is_signed = False
+
+    @property
+    def value(self):
+        if isinstance(self.rdt, Const):
+            return self.rdt.con.value
+        else:
+            raise ValueError("Non-constant VexValue has no value property")
+
+    def toSigned(self):
+        self.is_signed = True
+
+    def toUnsigned(self):
+        self.is_signed = False
+
+    @vvifyresults
+    def widen_unsigned(self, ty):
+        return self.irsb_c.op_widen_int_unsigned(self.rdt, ty)
+
+    @vvifyresults
+    def cast_to(self, ty, signed=False, high=False):
+        return self.irsb_c.cast_to(self.rdt, ty, signed=signed, high=high)
+
+    @vvifyresults
+    def widen_signed(self, ty):
+        return self.irsb_c.op_widen_int_signed(self.rdt, ty)
+
+    @vvifyresults
+    def narrow_high(self, ty):
+        return self.irsb_c.op_narrow_int(self.rdt, ty, high_half=True)
+
+    @vvifyresults
+    def narrow_low(self, ty):
+        return self.irsb_c.op_narrow_int(self.rdt, ty, high_half=False)
+
+    # TODO at some point extend this to Vex nonconstants
+    def __getitem__(self, idx):
+        getb = lambda i: VexValue(self.irsb_c, self.irsb_c.get_bit(self.rdt, i))
+        makeconstant = lambda x: VexValue.Constant(self.irsb_c, x, Type.int_8).rdt
+        if not isinstance(idx, slice):
+            actualindex = slice(idx).indices(self.width)[1]
+            return getb(makeconstant(actualindex))
+        else:
+            return [getb(makeconstant(i)) for i in xrange(*idx.indices(self.width))]
+
+    @checkparams
+    @vvifyresults
+    def set_bit(self, idx, bval):
+        typedidx = idx.cast_to(Type.int_8)
+        return self.irsb_c.set_bit(self.rdt, idx.rdt, bval.rdt)
+
+    @checkparams
+    @vvifyresults
+    def set_bits(self, idxsandvals):
+        return self.irsb_c.set_bits(self.rdt, [(i.cast_to(Type.int_8).rdt, b.rdt) for i, b in idxsandvals])
+
+    @checkparams
+    @vvifyresults
+    def ite(self, iftrue, iffalse):
+        onebitcond = self.cast_to(Type.int_1)
+        return self.irsb_c.ite(onebitcond.rdt, iftrue.rdt, iffalse.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __add__(self, right):
+        return self.irsb_c.op_add(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __sub__(self, right): # I'm not sure if we want rsub
+        return self.irsb_c.op_sub(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __div__(self, right):
+        return self.irsb_c.op_div(self.rdt, right.rdt, self.is_signed)
+
+    @checkparams
+    @vvifyresults
+    def __floordiv__(self, right): # Note: nonprimitive
+        return self / right
+
+    @checkparams
+    @vvifyresults
+    def __truediv__(self, right): # Note: nonprimitive
+        return self / right
+
+    @checkparams
+    @vvifyresults
+    def __and__(self, right):
+        return self.irsb_c.op_and(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __eq__(self, right):
+        return self.irsb_c.op_cmp_eq(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __ne__(self, other):
+        return self.irsb_c.op_cmp_ne(self.rdt, other.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __invert__(self):
+        return self.irsb_c.op_not(self.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __le__(self, right):
+        if self.is_signed:
+            return self.irsb_c.op_cmp_sle(self.rdt, right.rdt)
+        else:
+            return self.irsb_c.op_cmp_ule(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __gt__(self, other):
+        if self.is_signed:
+            return self.irsb_c.op_cmp_sgt(self.rdt, other.rdt)
+        else:
+            return self.irsb_c.op_cmp_ugt(self.rdt, other.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __ge__(self, right):
+        if self.is_signed:
+            return self.irsb_c.op_cmp_sge(self.rdt, right.rdt)
+        else:
+            return self.irsb_c.op_cmp_uge(self.rdt, right.rdt)
+
+    @checkparams(rhstype=Type.int_8)
+    @vvifyresults
+    def __lshift__(self, right):
+        return self.irsb_c.op_shl(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __lt__(self, right):
+        if self.is_signed:
+            return self.irsb_c.op_cmp_slt(self.rdt, right.rdt)
+        else:
+            return self.irsb_c.op_cmp_ult(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __mod__(self, right): # Note: nonprimitive
+        return self.rdt - (self.rdt / right.rdt) * right.rdt
+
+    @checkparams
+    @vvifyresults
+    def __mul__(self, right):
+        return self.irsb_c.op_mull(self.rdt, right.rdt, signed=self.is_signed)
+
+    @checkparams
+    @vvifyresults
+    def __neg__(self): # Note: nonprimitive
+        if self.is_unsigned:
+            raise Exception('Number is unsigned, cannot change sign!')
+        else:
+            return self.rdt * -1
+
+    @checkparams
+    @vvifyresults
+    def __or__(self, right):
+        return self.irsb_c.op_or(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __pos__(self):
+        return self
+
+    @checkparams
+    @vvifyresults
+    def __rshift__(self, right):
+        return self.irsb_c.op_shr(self.rdt, right.rdt)
+
+    @checkparams
+    @vvifyresults
+    def __xor__ (self, right):
+        return self.irsb_c.op_xor(self.rdt, right.rdt)
+
+    @classmethod
+    def Constant(cls, irsb_c, val, ty):
+        """
+        Creates a constant as a VexValue
+        :param irsb_c: The IRSBCustomizer to use
+        :param val: The value, as an integer
+        :param ty: The type of the resulting VexValue
+        :return: a VexValue
+        """
+        assert not (isinstance(val, VexValue) or isinstance(val, IRExpr))
+        rdt = irsb_c.mkconst(val, ty)
+        return cls(irsb_c, rdt)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pycparser
 cffi>=1.0.3
 archinfo
+bitstring

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
     name="pyvex", version='7.0.0.0rc1', description="A Python interface to libVEX and VEX IR.",
     packages=['pyvex', 'pyvex.lift', 'pyvex.lift.util'],
     cmdclass=cmdclass,
-    install_requires=[ 'pycparser', 'cffi>=1.0.3', 'archinfo' ],
+    install_requires=[ 'pycparser', 'cffi>=1.0.3', 'archinfo', 'bitstring' ],
     setup_requires=[ 'pycparser', 'cffi>=1.0.3' ],
     include_package_data=True,
     package_data={


### PR DESCRIPTION
This is the bulk of the Gymrat merge-set.

We will document the innards in extreme detail elsewhere, but the basic idea is as follows:
* Make writing lifters natural, by having the user focus on specifying what instructions do, not about an IR
* Make these semantics specifiable in a natural way, like "src + dst"
* Hide as much boiler-plate code inside pyvex as possible

The forthcoming angr_platforms repo/branch will have examples of how to use this.  Public interfaces have full docstrings.  I even wrote an (almost finished!) tutorial, continued from the one I started w/ angr-bf