### PR TITLE
Add a Mod operation to VEX.

### DIFF
--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -721,7 +721,7 @@ def unop_signature(op):
     return size_type, (size_type,)
 
 def binop_signature(op):
-    m = re.match(r'Iop_(Add|Sub|Mul|Xor|Or|And|Div[SU])(?P<size>\d+)$', op)
+    m = re.match(r'Iop_(Add|Sub|Mul|Xor|Or|And|Div[SU]|Mod)(?P<size>\d+)$', op)
     if m is None:
         raise PyvexOpMatchException()
     size = int(m.group('size'))

--- a/pyvex/lift/util/syntax_wrapper.py
+++ b/pyvex/lift/util/syntax_wrapper.py
@@ -212,7 +212,7 @@ class VexValue(object):
 
     @checkparams()
     def __mod__(self, right): # Note: nonprimitive
-        return self - (self / right) * right
+        return self.irsb_c.op_mod(self.rdt, right.rdt)
 
     @checkparams()
     def __rmod__(self, left):

--- a/pyvex/lift/util/vex_helper.py
+++ b/pyvex/lift/util/vex_helper.py
@@ -72,6 +72,9 @@ class IRSBCustomizer(object):
     op_sdiv = mkbinop('Iop_DivS{arg_t[0]}')
     op_udiv = mkbinop('Iop_DivU{arg_t[0]}')
 
+    # Custom operation that does not exist in libVEX
+    op_mod = mkbinop('Iop_Mod{arg_t[0]}')
+
     op_or = mkbinop('Iop_Or{arg_t[0]}')
     op_and = mkbinop('Iop_And{arg_t[0]}')
     op_xor = mkbinop('Iop_Xor{arg_t[0]}')


### PR DESCRIPTION
It can be handy when implementing support for some architectures.

Requires [angr PR 745](https://github.com/angr/angr/pull/745).