### PR TITLE
Small gymrat improvements

### DIFF
--- a/pyvex/lift/util/instr_helper.py
+++ b/pyvex/lift/util/instr_helper.py
@@ -89,7 +89,7 @@ class Instruction(object):
 
     def lift(self, irsb_c, past_instructions, future_instructions):
         """
-        THis is the main body of the "lifting" for the instruction.
+        This is the main body of the "lifting" for the instruction.
         This can/should be overriden to provide the general flow of how instructions in your arch work.
         For example, in MSP430, this is:
             1) Figure out what your operands are by parsing the addressing, and load them into temporary registers

--- a/pyvex/lift/util/syntax_wrapper.py
+++ b/pyvex/lift/util/syntax_wrapper.py
@@ -13,10 +13,10 @@ def checkparams(rhstype=None):
                        isinstance(a, VexValue)}  # pylint: disable=no-member
             assert len(irsb_cs) == 1, 'All VexValues must belong to the same irsb_c'
             args = list(args)
-            for arg in args:
+            for idx, arg in enumerate(args):
                 if isinstance(arg, int):
                     thetype = rhstype if rhstype else self.ty
-                    args[args.index(arg)] = VexValue.Constant(self.irsb_c, arg, thetype)
+                    args[idx] = VexValue.Constant(self.irsb_c, arg, thetype)
                 elif not isinstance(arg, VexValue):
                     raise Exception('Cannot convert param %s' % str(arg))
             args = tuple(args)
@@ -89,8 +89,6 @@ class VexValue(object):
     @checkparams()
     @vvifyresults
     def set_bit(self, idx, bval):
-        if isinstance(bval, int):
-            bval = VexValue.Constant(self.irsb_c, bval, Type.int_8)
         typedidx = idx.cast_to(Type.int_8)
         return self.irsb_c.set_bit(self.rdt, idx.rdt, bval.rdt)
 

--- a/pyvex/lift/util/syntax_wrapper.py
+++ b/pyvex/lift/util/syntax_wrapper.py
@@ -89,6 +89,8 @@ class VexValue(object):
     @checkparams()
     @vvifyresults
     def set_bit(self, idx, bval):
+        if isinstance(bval, int):
+            bval = VexValue.Constant(self.irsb_c, bval, Type.int_8)
         typedidx = idx.cast_to(Type.int_8)
         return self.irsb_c.set_bit(self.rdt, idx.rdt, bval.rdt)
 

--- a/pyvex/lift/util/vex_helper.py
+++ b/pyvex/lift/util/vex_helper.py
@@ -180,7 +180,8 @@ class IRSBCustomizer(object):
             for arg in args: assert isinstance(arg, RdTmp) or isinstance(arg, Const)
             arg_types = [self.get_type(arg) for arg in args]
             op = Operation(op_generator(arg_types), args)
-            assert op.typecheck(self.irsb.tyenv)
+            msg = "operation needs to be well typed: " + str(op)
+            assert op.typecheck(self.irsb.tyenv), msg + "\ntypes: " + str(self.irsb.tyenv)
             return self._settmp(op)
         return instance
 

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -1,0 +1,27 @@
+import nose
+import archinfo
+from pyvex.lift.util import *
+
+def test_partial_lift():
+    """This tests that gymrat correctly handles the case where an
+    instruction is longer than the remaining input.
+    """
+    class NOP(Instruction):
+        name = "nop"
+        bin_format = "0000111100001111"
+
+        def compute_result(self, *args):
+            pass
+
+    class NOPLifter(GymratLifter):
+        instrs = [NOP]
+
+    lifter = NOPLifter(archinfo.ArchAMD64(), 0)
+    # this should not throw an exception
+    block = lifter._lift("\x0F\x0Fa")
+    nose.tools.assert_equal(block.size, 2)
+    nose.tools.assert_equal(block.instructions, 1)
+    nose.tools.assert_equal(block.jumpkind, JumpKind.NoDecode)
+
+if __name__ == '__main__':
+    test_partial_lift()


### PR DESCRIPTION
I decided to catch every `bitstring.ReadError`, alternatively we could also change each use site to convert this into a `ParserError`. But I think catching `ReadError` should be safe, according to the docs that is only thrown if you try to read past the end of the bitstring.

I also removed the `catch Exception, e: raise e` block, correct me if I'm wrong but I think that was redundant?