### PR TITLE
Fix same RDT being used multiple times

### DIFF
--- a/pyvex/lift/util/syntax_wrapper.py
+++ b/pyvex/lift/util/syntax_wrapper.py
@@ -1,5 +1,6 @@
 
 import functools
+import copy
 
 from .vex_helper import IRSBCustomizer, Type, JumpKind
 import pyvex
@@ -37,9 +38,13 @@ class VexValue(object):
     def __init__(self, irsb_c, rdt, signed=False):
         self.irsb_c = irsb_c
         self.ty = self.irsb_c.get_type(rdt)
-        self.rdt = rdt
+        self._rdt = rdt
         self.width = pyvex.get_type_size(self.ty)
         self._is_signed = signed
+
+    @property
+    def rdt(self):
+        return copy.copy(self._rdt)
 
     @property
     def value(self):


### PR DESCRIPTION
Before, the same RDT would be used multiple times, so when the block appender went through and updated the tmps, it got very confused. This copies the rdt in the VexValue every time so this cannot happen.