### PR TITLE
instruction_helper: provide access to surrounding instructions

### DIFF
--- a/pyvex/lifting/util/instr_helper.py
+++ b/pyvex/lifting/util/instr_helper.py
@@ -108,20 +108,9 @@ class Instruction(object):
         self.data = self.parse(bitstrm)
 
     def __call__(self, irsb_c, past_instructions, future_instructions):
-        past_context = ContextInstructions(past_instructions, True)
-        future_context = ContextInstructions(future_instructions, False)
-        self.apply_context(past_context, future_context)
-        self.lift(irsb_c)
-
-    def apply_context(self, past_instructions, future_instructions):
-        """
-        Look at surrounding instructions to extract information necessary to interpret this instruction.
-
-        This can be used to implement instructions that require context, like "skip next instruction" which
-        requires the size of the next instruction. If at all possible, you should avoid large amounts of context
-        when possible.
-        """
-        pass
+        past  = ContextInstructions(past_instructions, True)
+        future = ContextInstructions(future_instructions, False)
+        self.lift(irsb_c, past, future)
 
     def mark_instruction_start(self):
         self.irsb_c.imark(self.addr, self.bytewidth, 0)
@@ -133,7 +122,17 @@ class Instruction(object):
         """
         return []
 
-    def lift(self, irsb_c):
+    def apply_context(self, past_instructions, future_instructions):
+        """
+        Look at surrounding instructions to extract information necessary to interpret this instruction.
+
+        This can be used to implement instructions that require context, like "skip next instruction" which
+        requires the size of the next instruction. If at all possible, you should avoid requiring large amounts
+        of context.
+        """
+        pass
+
+    def lift(self, irsb_c, past_instructions, future_instructions):
         """
         This is the main body of the "lifting" for the instruction.
         This can/should be overriden to provide the general flow of how instructions in your arch work.
@@ -147,6 +146,7 @@ class Instruction(object):
         # Always call this first!
         self.mark_instruction_start()
         # Then do the actual stuff.
+        self.apply_context(past_instructions, future_instructions)
         inputs = self.fetch_operands()
         retval = self.compute_result(*inputs)
         vals = list(inputs) + [retval]

--- a/pyvex/lifting/util/instr_helper.py
+++ b/pyvex/lifting/util/instr_helper.py
@@ -108,7 +108,7 @@ class Instruction(object):
         self.data = self.parse(bitstrm)
 
     def __call__(self, irsb_c, past_instructions, future_instructions):
-        past  = ContextInstructions(past_instructions, True)
+        past = ContextInstructions(past_instructions, True)
         future = ContextInstructions(future_instructions, False)
         self.lift(irsb_c, past, future)
 

--- a/pyvex/lifting/util/instr_helper.py
+++ b/pyvex/lifting/util/instr_helper.py
@@ -14,7 +14,7 @@ l = logging.getLogger("instr")
 class ContextInstructions(object):
     """Sequence of lookahead/lookback instruction context.
 
-    This sequence is list-like, but out-of-bounds raise a `RequireContextError`.
+    This sequence is list-like, but out-of-bounds accesses raise a `RequireContextError`.
     """
     def __init__(self, available, past):
         self._available = available

--- a/pyvex/lifting/util/lifter_helper.py
+++ b/pyvex/lifting/util/lifter_helper.py
@@ -55,7 +55,7 @@ class GymratLifter(Lifter):
         # Try every instruction until one works
         for possible_instr in self.instrs:
             try:
-                l.info("Trying " + possible_instr.name)
+                l.info("Trying %s", possible_instr.name)
                 return possible_instr(self.bitstrm, self.irsb.arch, addr)
             # a ParserError signals that this instruction did not match
             # we need to try other instructions, so we ignore this error
@@ -70,7 +70,7 @@ class GymratLifter(Lifter):
         # If no instruction matches, log an error
         errorstr = 'Unknown instruction at bit position %d' % self.bitstrm.bitpos
         l.debug(errorstr)
-        l.debug("Address: %#08x" % addr)
+        l.debug("Address: %#08x", addr)
 
     def decode(self):
         try:
@@ -78,7 +78,7 @@ class GymratLifter(Lifter):
             count = 0
             disas = []
             addr = self.irsb._addr
-            l.debug("Starting block at address: " + hex(addr))
+            l.debug("Starting block at address: %#08x", addr)
             bytepos = self.bitstrm.bytepos
 
 
@@ -86,7 +86,7 @@ class GymratLifter(Lifter):
                 instr = self._decode_next_instruction(addr)
                 if not instr: break
                 disas.append(instr)
-                l.debug("Matched " + instr.name)
+                l.debug("Matched %s", instr.name)
                 addr += self.bitstrm.bytepos - bytepos
                 bytepos = self.bitstrm.bytepos
                 count += 1
@@ -114,7 +114,7 @@ class GymratLifter(Lifter):
             # try to do the lifting
             # if the instruction requires more context, we stop
             # decoding here and just return the block we have so far
-            l.debug("Lifting instruction " + instr.name)
+            l.debug("Lifting instruction %s", instr.name)
             try:
                 instr(irsb_c, instructions[:i], instructions[i+1:])
             except RequireContextError:
@@ -130,15 +130,15 @@ class GymratLifter(Lifter):
                 self.irsb.jumpkind = JumpKind.Boring
                 break
 
-            # if the block has a jumpkind, this is a full block so we can exit 
+            # if the block has a jumpkind, this is a full block so we can exit
             if self.irsb.jumpkind is not None:
                 break
 
-        if len(self.irsb.statements) == 0:
+        if not self.irsb.statements:
             raise LiftingException('Could not lift any instructions')
 
         if self.irsb.jumpkind is None:
-            if len(instructions) >= self.max_inst and self.max_inst is not None:
+            if self.max_inst is not None and len(instructions) >= self.max_inst:
                 self.irsb.next = Const(vex_int_class(self.irsb.arch.bits)(self.irsb.addr + self.irsb.size))
                 self.irsb.jumpkind = JumpKind.Boring
             else:

--- a/pyvex/lifting/util/lifter_helper.py
+++ b/pyvex/lifting/util/lifter_helper.py
@@ -4,6 +4,7 @@ import bitstring
 
 from .vex_helper import *
 from ..lifter import Lifter
+from ...block import IRSB
 
 l = logging.getLogger(__name__)
 
@@ -108,7 +109,7 @@ class GymratLifter(Lifter):
         self.irsb.jumpkind = None
         for i, instr in enumerate(instructions[:self.max_inst]):
             # first, create a scratch IRSB so we can throw the changes away if lifting fails
-            next_irsb_part = pyvex.IRSB.empty_block(self.irsb.arch, self.irsb.addr)
+            next_irsb_part = IRSB.empty_block(self.irsb.arch, self.irsb.addr)
             irsb_c = IRSBCustomizer(next_irsb_part)
 
             # try to do the lifting

--- a/pyvex/lifting/util/vex_helper.py
+++ b/pyvex/lifting/util/vex_helper.py
@@ -104,6 +104,7 @@ class IRSBCustomizer(object):
     def __init__(self, irsb):
         self.arch = irsb.arch
         self.irsb = irsb
+        self.has_conditional_exit = False
 
     def get_type(self, rdt):
         return rdt.result_type(self.irsb.tyenv)
@@ -137,6 +138,7 @@ class IRSBCustomizer(object):
         :param ip: The address of this exit's source
         """
         self.irsb.statements.append(Exit(guard, dst, jk, ip))
+        self.has_conditional_exit = True
     # end statements
 
     def goto(self, addr):


### PR DESCRIPTION
I introduced a new `apply_context` to avoid the possibility of a partially-modified irsb, for example the following would be bad, as we would be left with a half-finished IRSB and we cannot revert the partial changes:

```
def compute_result(...):
    self.put(...) # this modifies the IRSB
    # do something that finds out that we need more context
```

Introducing a new method for inspecting the context makes it harder to screw this up.

I included the index in the exception to allow further enhancments, for example we could find a way to deal with requiring access to more past context by lifiting earlier instructions. The index can then be used to figure out what we should do to provide the required context.