### PR TITLE
Fix same RDT being used multiple times (now really)

### DIFF
--- a/pyvex/lift/util/syntax_wrapper.py
+++ b/pyvex/lift/util/syntax_wrapper.py
@@ -1,6 +1,5 @@
 
 import functools
-import copy
 
 from .vex_helper import IRSBCustomizer, Type, JumpKind
 import pyvex
@@ -38,13 +37,9 @@ class VexValue(object):
     def __init__(self, irsb_c, rdt, signed=False):
         self.irsb_c = irsb_c
         self.ty = self.irsb_c.get_type(rdt)
-        self._rdt = rdt
+        self.rdt = rdt
         self.width = pyvex.get_type_size(self.ty)
         self._is_signed = signed
-
-    @property
-    def rdt(self):
-        return copy.copy(self._rdt)
 
     @property
     def value(self):

--- a/pyvex/lift/util/vex_helper.py
+++ b/pyvex/lift/util/vex_helper.py
@@ -1,5 +1,6 @@
 from enum import Enum
 import re
+import copy
 from pyvex.const import ty_to_const_class, vex_int_class, get_type_size
 from pyvex.expr import IRExpr, Const, RdTmp, Unop, Binop, Triop, Qop, Load, CCall, Get, ITE
 from pyvex.stmt import WrTmp, Put, IMark, Store, NoOp, Exit
@@ -179,6 +180,8 @@ class IRSBCustomizer(object):
         def instance(*args): # Note: The args here are all RdTmps
             for arg in args: assert isinstance(arg, RdTmp) or isinstance(arg, Const)
             arg_types = [self.get_type(arg) for arg in args]
+            # two operations should never share the same argument instances, copy them here to ensure that
+            args = [copy.copy(a) for a in args]
             op = Operation(op_generator(arg_types), args)
             msg = "operation needs to be well typed: " + str(op)
             assert op.typecheck(self.irsb.tyenv), msg + "\ntypes: " + str(self.irsb.tyenv)


### PR DESCRIPTION
CC @Nilocunger

The issue is that vex_helper sometimes gets passed raw RDTs (such as for set_bit) and then uses
the twice, so the copy in syntax_wrapper is not enough.

Not sure if the previous fix is now redundant with this change (probably)?
In that case, I can also revert the previous fix.