### PR TITLE
Fix IRSB property caching

### DIFF
--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -102,6 +102,9 @@ class IRSB(VEXObject):
         conversion_dict = { }
         invalid_vals = (0xffffffff, -1)
 
+        new_size = self.size + extendwith.size
+        new_instructions = self.instructions + extendwith.instructions
+        new_direct_next = extendwith.direct_next
         def convert_tmp(tmp):
             """
             Converts a tmp from the appended-block into one in the appended-to-block. Creates a new tmp if it does not
@@ -145,8 +148,11 @@ class IRSB(VEXObject):
         convert_expr(extendwith.next)
         self.next = extendwith.next
         self.jumpkind = extendwith.jumpkind
-        self._size = None
-        self._instructions = None
+        self._size = new_size
+        self._instructions = new_instructions
+        self._direct_next = new_direct_next
+
+    def invalidate_direct_next(self):
         self._direct_next = None
 
     def pp(self):
@@ -423,7 +429,7 @@ class IRSB(VEXObject):
         self.next = expr.IRExpr._from_c(c_irsb.next)
         self.jumpkind = get_enum_from_int(c_irsb.jumpkind)
 
-    def _set_attributes(self, statements=None, nxt=None, tyenv=None, jumpkind=None, direct_next=None, size=None):
+    def _set_attributes(self, statements=None, nxt=None, tyenv=None, jumpkind=None, direct_next=None, size=None, instructions=None):
         self.statements = statements if statements is not None else []
         self.next = nxt
         if tyenv is not None:
@@ -431,9 +437,10 @@ class IRSB(VEXObject):
         self.jumpkind = jumpkind
         self._direct_next = direct_next
         self._size = size
+        self._instructions = instructions
 
     def _from_py(self, irsb):
-        self._set_attributes(irsb.statements, irsb.next, irsb.tyenv, irsb.jumpkind, irsb.direct_next, irsb.size)
+        self._set_attributes(irsb.statements, irsb.next, irsb.tyenv, irsb.jumpkind, irsb.direct_next, irsb.size, irsb.instructions)
 
 class IRTypeEnv(VEXObject):
     """

--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -144,6 +144,8 @@ class IRSB(VEXObject):
         convert_expr(extendwith.next)
         self.next = extendwith.next
         self.jumpkind = extendwith.jumpkind
+        self._size = None
+        self._instructions = None
 
     def pp(self):
         """
@@ -250,7 +252,9 @@ class IRSB(VEXObject):
         """
         The number of instructions in this block
         """
-        return len([s for s in self.statements if type(s) is stmt.IMark])
+        if self._instructions is None:
+            self._instructions = len([s for s in self.statements if type(s) is stmt.IMark])
+        return self._instructions
 
     @property
     def size(self):

--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -34,7 +34,7 @@ class IRSB(VEXObject):
     :ivar int addr:         The address of this basic block, i.e. the address in the first IMark
     """
 
-    __slots__ = ['_addr', 'arch', 'statements', 'next', 'tyenv', 'jumpkind', '_direct_next', '_size']
+    __slots__ = ['_addr', 'arch', 'statements', 'next', 'tyenv', 'jumpkind', '_direct_next', '_size', '_instructions']
 
     def __init__(self, data, mem_addr, arch, max_inst=None, max_bytes=None, bytes_offset=0, traceflags=0, opt_level=1, num_inst=None, num_bytes=None):
         """
@@ -74,6 +74,7 @@ class IRSB(VEXObject):
         self.jumpkind = None
         self._direct_next = None
         self._size = None
+        self._instructions = None
 
         if data is not None:
             lift(self, arch, mem_addr, data, max_bytes, max_inst, bytes_offset, opt_level, traceflags)
@@ -146,6 +147,7 @@ class IRSB(VEXObject):
         self.jumpkind = extendwith.jumpkind
         self._size = None
         self._instructions = None
+        self._direct_next = None
 
     def pp(self):
         """

--- a/pyvex/lift/__init__.py
+++ b/pyvex/lift/__init__.py
@@ -170,6 +170,7 @@ def lift(irsb, arch, addr, data, max_bytes=None, max_inst=None, bytes_offset=Non
     else:
         final_irsb.jumpkind = 'Ijk_NoDecode'
         final_irsb.next = Const(const.vex_int_class(final_irsb.arch.bits)(final_irsb._addr))
+        final_irsb.invalidate_direct_next()
         irsb._from_py(final_irsb)
         return
 

--- a/tests/test_irsb_property_caching.py
+++ b/tests/test_irsb_property_caching.py
@@ -1,0 +1,30 @@
+import pyvex
+import archinfo
+from pyvex.block import IRSB
+import nose.tools
+import sys
+
+def test_cache_invalidation_on_extend():
+    b = pyvex.block.IRSB('\x50', 0, archinfo.ArchX86())
+    nose.tools.assert_equal(b.size, 1)
+    nose.tools.assert_equal(b.instructions, 1)
+    toappend = pyvex.block.IRSB('\x51', 0, archinfo.ArchX86())
+    toappend.jumpkind = 'Ijk_Invalid'
+    toappend._direct_next = None # Invalidate the cache because I manually changed the jumpkind
+    nose.tools.assert_equal(toappend.direct_next, False)
+    b.extend(toappend)
+    nose.tools.assert_equal(b.size, 2)
+    nose.tools.assert_equal(b.instructions, 2)
+    nose.tools.assert_equal(b.direct_next, False)
+
+def run_all():
+    g = globals()
+    for k, v in g.iteritems():
+        if k.startswith('test_') and hasattr(v, '__call__'):
+            v()
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        globals()['test_' + sys.argv[1]]()
+    else:
+        run_all()


### PR DESCRIPTION
In the case of extending an IRSB, the cache could be left in an incorrect state causing incorrect reporting of IRSB sizes and other properties. Add in updating of the caches on extension, some manual cache invalidation, and a basic test to check for future caching errors.