### PR TITLE
Fix CB{N}Z thumb instruction second attempt

### DIFF
--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -36,21 +36,23 @@ class IRSB(VEXObject):
 
     __slots__ = ['_addr', 'arch', 'statements', 'next', 'tyenv', 'jumpkind', '_direct_next', '_size', '_instructions']
 
-    def __init__(self, data, mem_addr, arch, max_inst=None, max_bytes=None, bytes_offset=0, traceflags=0, opt_level=1, num_inst=None, num_bytes=None):
+    def __init__(self, data, mem_addr, arch, max_inst=None, max_bytes=None,
+                 bytes_offset=0, traceflags=0, opt_level=1, num_inst=None, num_bytes=None, strict_block_end=True):
         """
-        :param data:            The bytes to lift. Can be either a string of bytes or a cffi buffer object.
-                                You may also pass None to initialize an empty IRSB.
-        :type data:             str or bytes or cffi.FFI.CData or None
-        :param int mem_addr:    The address to lift the data at.
-        :param arch:            The architecture to lift the data as.
-        :type arch:             :class:`archinfo.Arch`
-        :param max_inst:        The maximum number of instructions to lift. (See note below)
-        :param max_bytes:       The maximum number of bytes to use.
-        :param num_inst:        Replaces max_inst if max_inst is None. If set to None as well, no instruction limit is used.
-        :param num_bytes:       Replaces max_bytes if max_bytes is None. If set to None as well, no  byte limit is used.
-        :param bytes_offset:    The offset into `data` to start lifting at.
-        :param traceflags:      The libVEX traceflags, controlling VEX debug prints.
-        :param opt_level:       The level of optimization to apply to the IR, 0-2. 2 is highest, 0 is no optimization.
+        :param data:                The bytes to lift. Can be either a string of bytes or a cffi buffer object.
+                                    You may also pass None to initialize an empty IRSB.
+        :type data:                 str or bytes or cffi.FFI.CData or None
+        :param int mem_addr:        The address to lift the data at.
+        :param arch:                The architecture to lift the data as.
+        :type arch:                 :class:`archinfo.Arch`
+        :param max_inst:            The maximum number of instructions to lift. (See note below)
+        :param max_bytes:           The maximum number of bytes to use.
+        :param num_inst:            Replaces max_inst if max_inst is None. If set to None as well, no instruction limit is used.
+        :param num_bytes:           Replaces max_bytes if max_bytes is None. If set to None as well, no  byte limit is used.
+        :param bytes_offset:        The offset into `data` to start lifting at.
+        :param traceflags:          The libVEX traceflags, controlling VEX debug prints.
+        :param opt_level:           The level of optimization to apply to the IR, 0-2. 2 is highest, 0 is no optimization.
+        :param strict_block_end:    The level of optimization to apply to the IR, 0-2. 2 is highest, 0 is no optimization.
 
         .. note:: Explicitly specifying the number of instructions to lift (`max_inst`) may not always work
                   exactly as expected. For example, on MIPS, it is meaningless to lift a branch or jump
@@ -77,7 +79,7 @@ class IRSB(VEXObject):
         self._instructions = None
 
         if data is not None:
-            lift(self, arch, mem_addr, data, max_bytes, max_inst, bytes_offset, opt_level, traceflags)
+            lift(self, arch, mem_addr, data, max_bytes, max_inst, bytes_offset, opt_level, traceflags, strict_block_end)
 
     @staticmethod
     def empty_block(arch, addr, statements=None, nxt=None, tyenv=None, jumpkind=None, direct_next=None, size=None):

--- a/pyvex/lifting/__init__.py
+++ b/pyvex/lifting/__init__.py
@@ -14,7 +14,7 @@ class LiftingException(Exception):
     pass
 
 
-def lift(irsb, arch, addr, data, max_bytes=None, max_inst=None, bytes_offset=None, opt_level=1, traceflags=False):
+def lift(irsb, arch, addr, data, max_bytes=None, max_inst=None, bytes_offset=None, opt_level=1, traceflags=False, strict_block_end=True):
     """
     Recursively lifts blocks using the registered lifters and postprocessors. Tries each lifter in the order in
     which they are registered on the data to lift.
@@ -79,7 +79,7 @@ def lift(irsb, arch, addr, data, max_bytes=None, max_inst=None, bytes_offset=Non
                     u_data = ffi.buffer(c_data, max_bytes)[:]
                 else:
                     u_data = py_data
-            next_irsb_part = lifter(arch, addr)._lift(u_data, bytes_offset, max_bytes, max_inst, opt_level, traceflags, allow_lookback)
+            next_irsb_part = lifter(arch, addr)._lift(u_data, bytes_offset, max_bytes, max_inst, opt_level, traceflags, allow_lookback, strict_block_end)
             #l.debug('block lifted by %s' % str(lifter))
             #l.debug(str(next_irsb_part))
             final_irsb.extend(next_irsb_part)

--- a/pyvex/lifting/libvex.py
+++ b/pyvex/lifting/libvex.py
@@ -45,6 +45,9 @@ class LibVEXLifter(Lifter):
             else:
                 max_inst = self.max_inst
 
+            if self.strict_block_end is None:
+                strict_block_end = True
+
             self.irsb.arch.vex_archinfo['hwcache_info']['caches'] = ffi.NULL
             c_irsb = pvc.vex_lift(vex_arch,
                                   self.irsb.arch.vex_archinfo,
@@ -54,7 +57,8 @@ class LibVEXLifter(Lifter):
                                   max_bytes,
                                   self.opt_level,
                                   self.traceflags,
-                                  self.allow_lookback)
+                                  self.allow_lookback,
+                                  self.strict_block_end)
             log_str = self.get_vex_log()
             if c_irsb == ffi.NULL:
                 raise LiftingException("libvex: unkown error" if log_str is None else log_str)

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -6,16 +6,17 @@ class Lifter(object):
     """
     A lifter is a class of methods for processing a block.
 
-    :ivar data:            The bytes to lift as either a python string of bytes or a cffi buffer object.
-    :ivar bytes_offset:    The offset into `data` to start lifting at.
-    :ivar max_bytes:       The maximum number of bytes to lift. If set to None, no byte limit is used.
-    :ivar max_inst:        The maximum number of instructions to lift. If set to None, no instruction limit is used.
-    :ivar opt_level:       The level of optimization to apply to the IR, 0-2. Most likely will be ignored in any lifter
-                           other then LibVEX.
-    :ivar traceflags:      The libVEX traceflags, controlling VEX debug prints. Most likely will be ignored in any lifter
-                           other than LibVEX.
-    :ivar allow_lookback:  Should the LibVEX arm-thumb lifter be allowed to look before the current instruction pointer.
-                           Most likely will be ignored in any lifter other than LibVEX.
+    :ivar data:             The bytes to lift as either a python string of bytes or a cffi buffer object.
+    :ivar bytes_offset:     The offset into `data` to start lifting at.
+    :ivar max_bytes:        The maximum number of bytes to lift. If set to None, no byte limit is used.
+    :ivar max_inst:         The maximum number of instructions to lift. If set to None, no instruction limit is used.
+    :ivar opt_level:        The level of optimization to apply to the IR, 0-2. Most likely will be ignored in any lifter
+                            other then LibVEX.
+    :ivar traceflags:       The libVEX traceflags, controlling VEX debug prints. Most likely will be ignored in any lifter
+                            other than LibVEX.
+    :ivar allow_lookback:   Should the LibVEX arm-thumb lifter be allowed to look before the current instruction pointer.
+                            Most likely will be ignored in any lifter other than LibVEX.
+    :ivar strict_block_end: Should the LibVEX arm-thumb split block at some instructions, for example CB{N}Z.
     """
     REQUIRE_DATA_C = False
     REQUIRE_DATA_PY = False
@@ -31,20 +32,22 @@ class Lifter(object):
              max_inst=None,
              opt_level=1,
              traceflags=None,
-             allow_lookback=None):
+             allow_lookback=None,
+             strict_block_end=None):
         """
         Wrapper around the `lift` method on Lifters. Should not be overridden in child classes.
 
-        :param data:            The bytes to lift as either a python string of bytes or a cffi buffer object.
-        :param bytes_offset:    The offset into `data` to start lifting at.
-        :param max_bytes:       The maximum number of bytes to lift. If set to None, no byte limit is used.
-        :param max_inst:        The maximum number of instructions to lift. If set to None, no instruction limit is used.
-        :param opt_level:       The level of optimization to apply to the IR, 0-2. Most likely will be ignored in any lifter
-                                other then LibVEX.
-        :param traceflags:      The libVEX traceflags, controlling VEX debug prints. Most likely will be ignored in any
-                                lifter other than LibVEX.
-        :param allow_lookback:  Should the LibVEX arm-thumb lifter be allowed to look before the current instruction pointer.
-                                Most likely will be ignored in any lifter other than LibVEX.
+        :param data:                The bytes to lift as either a python string of bytes or a cffi buffer object.
+        :param bytes_offset:        The offset into `data` to start lifting at.
+        :param max_bytes:           The maximum number of bytes to lift. If set to None, no byte limit is used.
+        :param max_inst:            The maximum number of instructions to lift. If set to None, no instruction limit is used.
+        :param opt_level:           The level of optimization to apply to the IR, 0-2. Most likely will be ignored in any lifter
+                                    other then LibVEX.
+        :param traceflags:          The libVEX traceflags, controlling VEX debug prints. Most likely will be ignored in any
+                                    lifter other than LibVEX.
+        :param allow_lookback:      Should the LibVEX arm-thumb lifter be allowed to look before the current instruction pointer.
+                                    Most likely will be ignored in any lifter other than LibVEX.
+        :param strict_block_end:    Should the LibVEX arm-thumb split block at some instructions, for example CB{N}Z.
         """
         irsb = IRSB.empty_block(self.arch, self.addr)
         self.data = data
@@ -52,6 +55,7 @@ class Lifter(object):
         self.opt_level = opt_level
         self.traceflags = traceflags
         self.allow_lookback = allow_lookback
+        self.strict_block_end = strict_block_end
         self.max_inst = max_inst
         self.max_bytes = max_bytes
         self.irsb = irsb

--- a/pyvex_c/pyvex.c
+++ b/pyvex_c/pyvex.c
@@ -119,15 +119,6 @@ void vex_init() {
 	LibVEX_default_VexArchInfo(&vai_host);
 	LibVEX_default_VexAbiInfo(&vbi);
 
-	vc.iropt_verbosity              = 0;
-	vc.iropt_level                  = 0;    // No optimization by default
-	//vc.iropt_precise_memory_exns    = False;
-	vc.iropt_unroll_thresh          = 0;
-	vc.guest_max_insns              = 1;    // By default, we vex 1 instruction at a time
-	vc.guest_chase_thresh           = 0;
-	vc.arm64_allow_reordered_writeback = 0;
-	vc.x86_optimize_callpop_idiom = 0;
-
 	pyvex_debug("Calling LibVEX_Init()....\n");
 	// the 0 is the debug level
 	LibVEX_Init(&failure_exit, &log_bytes, 0, &vc);
@@ -289,7 +280,8 @@ IRSB *vex_lift(
 		unsigned int max_bytes,
 		int opt_level,
 		int traceflags,
-		int allow_lookback) {
+		int allow_lookback,
+		int strict_block_end) {
 	VexRegisterUpdates pxControl;
 
 	vex_prepare_vai(guest, &archinfo);
@@ -310,6 +302,7 @@ IRSB *vex_lift(
 	vc.guest_max_insns     = max_insns;
 	vc.iropt_level         = opt_level;
 	vc.arm_allow_optimizing_lookback = allow_lookback;
+        vc.arm_strict_block_end = strict_block_end;
 
 	clear_log();
 

--- a/pyvex_c/pyvex.h
+++ b/pyvex_c/pyvex.h
@@ -28,6 +28,7 @@ IRSB *vex_lift(
 		unsigned int max_bytes,
 		int opt_level,
 		int traceflags,
-		int allow_lookback);
+		int allow_lookback,
+		int strict_block_end);
 
 #endif


### PR DESCRIPTION
Added `strict_block_end` parameter everywhere in python vex lifting functionality, so it could be passed to `libvex.so`.

**WARNING**: This PR will break `angr/native/sim_unicorn.cpp` as it has call to `vex_lift`