### PR TITLE
Remove tag setting, it causes an AttributeError

### DIFF
--- a/pyvex/lifting/fixes.py
+++ b/pyvex/lifting/fixes.py
@@ -201,7 +201,6 @@ class FixesPostProcessor(Postprocessor):
                         # Create a new IRConst
                         irconst = expr.Const.__new__(expr.Const)    # XXX: does this work???
                         irconst.con = dst
-                        irconst.tag = 'Iex_Const'
 
                         self.irsb.statements = self.irsb.statements[: exit_stt_idx] + self.irsb.statements[exit_stt_idx + 1:]
                         # Replace the default exit!


### PR DESCRIPTION
Since the addition of slots to in commit 61efbdcf6303a936aa3de35011d2d1e3fe5fdea5 we can't create new instance properties anymore.
