### PR TITLE
Lifter: Do not extend a basic block if the lifter intentionally ends it with a NoDecode.

### DIFF
--- a/tests/test_ud2.py
+++ b/tests/test_ud2.py
@@ -1,0 +1,21 @@
+
+import nose.tools
+
+import archinfo
+import pyvex
+
+
+def test_ud2():
+
+    # On x86 and amd64, ud2 is a valid 2-byte instruction that means "undefined instruction". Upon decoding a basic
+    # block that ends with ud2, we should treat it as an explicit NoDecode, instead of skipping the instruction and
+    # resume lifting.
+
+    b = pyvex.block.IRSB('\x90\x90\x0f\x0b\x90\x90', 0x20, archinfo.ArchAMD64())
+    nose.tools.assert_equals(b.jumpkind, "Ijk_NoDecode")
+    nose.tools.assert_equals(b.next.con.value, 0x22)
+    nose.tools.assert_equals(b.size, 4)
+
+
+if __name__ == "__main__":
+    test_ud2()


### PR DESCRIPTION
The rationale behind is that we want to differentiate between NoDecode
that are caused by unsupported instructions and NoDecode caused by
decodeable instructions. For example, `ud2` is a valid instruction on X86
and AMD64, but it means "undefined instruction". On AMD64, VEX will create
a basic block that has an instruction of two bytes (which is the size of
the ud2 instruction), but with the `next` of the basic block pointing to
that instruction. In our existing implementation, we will ignore ud2 and
keep lifting, which is an incorrect behavior.

This commit will detect these intentional NoDecode cases. In such cases,
the Lifter will return a basic block that terminates after the
"undecodeable" instruction, with NoDecode as the jumpkind.