### PR TITLE
Bugfix: prevent from raising exception when data type is str in python2

### DIFF
--- a/pyvex/lifting/__init__.py
+++ b/pyvex/lifting/__init__.py
@@ -52,7 +52,7 @@ def lift(data, addr, arch, max_bytes=None, max_inst=None, bytes_offset=0, opt_le
     if not data:
         raise PyVEXError("cannot lift block with no data (data is empty)")
 
-    if isinstance(data, str):
+    if str != bytes and isinstance(data, str):
         raise TypeError("Cannot pass unicode string as data to lifter")
 
     if isinstance(data, bytes):


### PR DESCRIPTION
If pyvex shall also support python2 this is necessary since this exception is always thrown when using python2.

```
    if isinstance(data, str):  <-- This is always true if str or bytes are used. 
        raise TypeError("Cannot pass unicode string as data to lifter")
    if isinstance(data, bytes):
```

