### PR TITLE
a couple of bug fixes

### DIFF
--- a/pyvex/lifting/__init__.py
+++ b/pyvex/lifting/__init__.py
@@ -161,7 +161,7 @@ def lift(data, addr, arch, max_bytes=None, max_inst=None, bytes_offset=0, opt_le
             data_left = data + final_irsb.size
         if max_inst is not None:
             max_inst -= final_irsb.instructions
-        if max_bytes > 0 and (max_inst is None or max_inst > 0):
+        if (max_bytes is None or max_bytes > 0) and (max_inst is None or max_inst > 0) and data_left:
             more_irsb = lift(data_left, next_addr, arch,
                              max_bytes=max_bytes,
                              max_inst=max_inst,

--- a/pyvex_c/pyvex.c
+++ b/pyvex_c/pyvex.c
@@ -267,9 +267,12 @@ static void vex_prepare_vai(VexArch arch, VexArchInfo *vai) {
 // Prepare the VexAbiInfo
 static void vex_prepare_vbi(VexArch arch, VexAbiInfo *vbi) {
 	// only setting the guest_stack_redzone_size for now
-	// this attribute is only specified by the PPC64 and AMD64 ABIs
+	// this attribute is only specified by the X86, AMD64 and PPC64 ABIs
 
 	switch (arch) {
+		case VexArchX86:
+			vbi->guest_stack_redzone_size = 0;
+			break;
 		case VexArchAMD64:
 			vbi->guest_stack_redzone_size = 128;
 			break;


### PR DESCRIPTION
Hi,

a few bug fixes (well I hope :-)

- cbd4aa1: when using multiple lifters, first lifter may not decode anything and max_bytes may be None or decode everything and data_left would be b'' or ''. both cases were leading to exceptions
- 17b0181: `guest_stack_redzone_size` is asserted [here](https://github.com/angr/vex/blob/master/priv/guest_x86_toIR.c#L6786) but only set to 0 during lib initialization. If a block is lifted for AMD64 or PPC64 the value of `guest_stack_redzone_size` would be changed in `vex_prepare_vbi`, and then subsequent x86 block liftings hitting this assert would fail.