### PR TITLE
Fix bugs in arm_post_processor_determine_calls()

### DIFF
--- a/pyvex_c/postprocess.c
+++ b/pyvex_c/postprocess.c
@@ -90,11 +90,15 @@ void arm_post_processor_determine_calls(
 					IRConst *con = stmt->Ist.Put.data->Iex.Const.con;
 					if (get_value_from_const_expr(con) == next_irsb_addr) {
 						lr_store_pc = 1;
+					} else {
+						lr_store_pc = 0;
 					}
 				} else if (stmt->Ist.Put.data->tag == Iex_RdTmp) {
 					Int tmp = stmt->Ist.Put.data->Iex.RdTmp.tmp;
 					if (tmp <= MAX_TMP && next_irsb_addr == tmps[tmp]) {
 						lr_store_pc = 1;
+					} else {
+						lr_store_pc = 0;
 					}
 				}
 				break;

--- a/pyvex_c/postprocess.c
+++ b/pyvex_c/postprocess.c
@@ -44,8 +44,17 @@ void arm_post_processor_determine_calls(
 	}
 
 	// Emulated CPU context
-	Addr tmps[MAX_TMP + 1] = { DUMMY };
-	Addr regs[MAX_REG_OFFSET + 1] = { DUMMY };
+	Addr tmps[MAX_TMP + 1];
+	Addr regs[MAX_REG_OFFSET + 1];
+
+    // Initialize context
+    for (i = 0; i <= MAX_TMP; ++i) {
+        tmps[i] = DUMMY;
+    }
+
+    for (i = 0; i <= MAX_REG_OFFSET; ++i) {
+        regs[i] = DUMMY;
+    }
 
 	Int lr_store_pc = 0;
 	Int inst_ctr = 0;


### PR DESCRIPTION
The first commit fixes the bug in `tmps` and `regs` initialization code:

```c
	Addr tmps[MAX_TMP + 1] = { DUMMY };
	Addr regs[MAX_REG_OFFSET + 1] = { DUMMY };
```
In that code only the first element will get its value initialized to DUMMY, while all other elements will be initialized to zero. See https://stackoverflow.com/a/201116 for reference.

Interesting, that with the code above the following block gets its jumpkind set to Ijk_Call:

```
.text:0001A648                 LDR     R3, [SP,#0x180+var_68]
.text:0001A64C                 LDR     LR, =(sub_17C3C - 0x1A65C)
.text:0001A650                 CMP     R3, #2
.text:0001A654                 ADD     LR, PC, LR      ; sub_17C3C
.text:0001A658                 BEQ     loc_1AF50
```
... since the LDR instruction is ignored by the postprocessor and the addition at 0x1a654 results in
`LR = PC + 0`.

The second commit ensures that at the end of the computation the lr_store_pc variable will be set if and only if it contains the next_irsb_addr.