### PR TITLE
Fixes pathname issue with "()" in Path.

### DIFF
--- a/pyvex_c/Makefile
+++ b/pyvex_c/Makefile
@@ -41,7 +41,7 @@ all: $(LIBRARY_FILE) $(STATIC_LIBRARY_FILE)
 	$(CC) -c $(CFLAGS) $<
 
 $(LIBRARY_FILE): $(OBJECTS) $(HEADERS) $(call sq,$(VEX_LIB_PATH)/libvex.a)
-	$(CC) $(CFLAGS) -o $(LIBRARY_FILE) $(OBJECTS) $(call sq,$(VEX_LIB_PATH)/libvex.a) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(LIBRARY_FILE) $(OBJECTS) "$(VEX_LIB_PATH)/libvex.a" $(LDFLAGS)
 
 $(STATIC_LIBRARY_FILE): $(OBJECTS) $(HEADERS) $(call sq,$(VEX_LIB_PATH)/libvex.a)
 	$(AR) rcs $(STATIC_LIBRARY_FILE) $(OBJECTS)


### PR DESCRIPTION
Despite the insane sq function used to handle paths with spaces, if you have a path with parenthesis (which Dropbox does by default when you have multiple Dropbox accounts) pyvex will not compile. 

Even though I'm using symbolic links so that there is no space or parenthesis, pyvex blows up (something is expanding to the full path name).

This usage of the `call sq` is not needed, because it's used as part of the path and can be enclosed in double quotes. 