### PR TITLE
Fix uncast bit index

### DIFF
--- a/pyvex/lifting/util/syntax_wrapper.py
+++ b/pyvex/lifting/util/syntax_wrapper.py
@@ -92,7 +92,7 @@ class VexValue(object):
     @vvifyresults
     def set_bit(self, idx, bval):
         typedidx = idx.cast_to(Type.int_8)
-        return self.irsb_c.set_bit(self.rdt, idx.rdt, bval.rdt)
+        return self.irsb_c.set_bit(self.rdt, typedidx.rdt, bval.rdt)
 
     @checkparams()
     @vvifyresults


### PR DESCRIPTION
The original idx variable is not necessarily of type int_8. This was probably noticed since it was cast to int_8 in a new variable, but this variable was not used.