### PR TITLE
adjust sample code in readme for python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ import pyvex
 import archinfo
 
 # translate an AMD64 basic block (of nops) at 0x400400 into VEX
-irsb = pyvex.lift("\x90\x90\x90\x90\x90", 0x400400, archinfo.ArchAMD64())
+irsb = pyvex.lift(b"\x90\x90\x90\x90\x90", 0x400400, archinfo.ArchAMD64())
 
 # pretty-print the basic block
 irsb.pp()
 
 # this is the IR Expression of the jump target of the unconditional exit at the end of the basic block
-print irsb.next
+print(irsb.next)
 
 # this is the type of the unconditional exit (i.e., a call, ret, syscall, etc)
-print irsb.jumpkind
+print(irsb.jumpkind)
 
 # you can also pretty-print it
 irsb.next.pp()
@@ -52,30 +52,30 @@ for stmt in irsb.statements:
 import pyvex
 for stmt in irsb.statements:
     if isinstance(stmt, pyvex.IRStmt.Store):
-        print "Data:",
+        print("Data:", end="")
         stmt.data.pp()
-        print ""
+        print("")
 
-        print "Type:",
-        print stmt.data.result_type
-        print ""
+        print("Type:", end="")
+        print(stmt.data.result_type)
+        print("")
 
 # pretty-print the condition and jump target of every conditional exit from the basic block
 for stmt in irsb.statements:
     if isinstance(stmt, pyvex.IRStmt.Exit):
-        print "Condition:",
+        print("Condition:", end="")
         stmt.guard.pp()
-        print ""
+        print("")
 
-        print "Target:",
+        print("Target:", end="")
         stmt.dst.pp()
-        print ""
+        print("")
 
 # these are the types of every temp in the IRSB
-print irsb.tyenv.types
+print(irsb.tyenv.types)
 
 # here is one way to get the type of temp 0
-print irsb.tyenv.types[0]
+print(irsb.tyenv.types[0])
 ```
 
 Keep in mind that this is a *syntactic* respresentation of a basic block. That is, it'll tell you what the block means, but you don't have any context to say, for example, what *actual* data is written by a store instruction.


### PR DESCRIPTION
This adjusts the sample code in the readme to be valid Python 3 syntax.

It doesn't fully work however as it results in the following for me:

```
Traceback (most recent call last):
  File "/tmp/readme.py", line 50, in <module>
    print(irsb.tyenv.types[0])
IndexError: list index out of range
```

But I cannot check whether this was already the case when pyvex was still Python 2.