### PR TITLE
Replace xrange for range and remove __future__.print_function import.

### DIFF
--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import copy
 import sys
 import itertools

--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -12,14 +12,6 @@ from .data_ref import DataRef
 from .errors import SkipStatementsError
 
 
-# Some Python 3 compatibility shims
-if sys.version_info.major < 3:
-    STRING_TYPES = (str, unicode)
-else:
-    STRING_TYPES = str
-    xrange = range  # pylint:disable=redefined-builtin
-
-
 import logging
 l = logging.getLogger("pyvex.block")
 
@@ -505,7 +497,7 @@ class IRSB(VEXObject):
             if lift_r.exit_count > self.MAX_EXITS:
                 # There are more exits than the default size of the exits array. We will need all statements
                 raise SkipStatementsError("exit_count exceeded MAX_EXITS (%d)" % self.MAX_EXITS)
-            for i in xrange(lift_r.exit_count):
+            for i in range(lift_r.exit_count):
                 ex = lift_r.exits[i]
                 exit_stmt = stmt.IRStmt._from_c(ex.stmt)
                 self._exit_statements.append((ex.ins_addr, ex.stmt_idx, exit_stmt))
@@ -524,7 +516,7 @@ class IRSB(VEXObject):
         if lift_r.data_ref_count > 0:
             if lift_r.data_ref_count > self.MAX_DATA_REFS:
                 raise SkipStatementsError("data_ref_count exceeded MAX_DATA_REFS (%d)" % self.MAX_DATA_REFS)
-            self.data_refs = [DataRef.from_c(lift_r.data_refs[i]) for i in xrange(lift_r.data_ref_count)]
+            self.data_refs = [DataRef.from_c(lift_r.data_refs[i]) for i in range(lift_r.data_ref_count)]
 
     def _set_attributes(self, statements=None, nxt=None, tyenv=None, jumpkind=None, direct_next=None, size=None,
                         instructions=None, instruction_addresses=None, exit_statements=None, default_exit_target=None):

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from past.builtins import xrange
 import re
 
 from . import VEXObject, ffi, pvc
@@ -294,7 +293,7 @@ class V128(IRConst):
     def _from_c(c_const):
         base_const = c_const.Ico.V128
         real_const = 0
-        for i in xrange(16):
+        for i in range(16):
             if (base_const >> i) & 1 == 1:
                 real_const |= 0xff << (8 * i)
         return V128(real_const)
@@ -319,7 +318,7 @@ class V256(IRConst):
     def _from_c(c_const):
         base_const = c_const.Ico.V256
         real_const = 0
-        for i in xrange(32):
+        for i in range(32):
             if (base_const >> i) & 1 == 1:
                 real_const |= 0xff << (8 * i)
         return V256(real_const)

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import re
 
 from . import VEXObject, ffi, pvc

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import re
 import logging
 

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 
 from . import VEXObject

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import pyvex
 import nose
 import random

--- a/tests/test_arm_postprocess.py
+++ b/tests/test_arm_postprocess.py
@@ -1,4 +1,3 @@
-from past.builtins import xrange
 import pyvex
 import archinfo
 import nose
@@ -7,7 +6,7 @@ import nose
 ### ARM Postprocessing ###
 ##########################
 def test_arm_postprocess_call():
-    for i in xrange(3):
+    for i in range(3):
         # Thumb
 
         # push  {r7}
@@ -296,7 +295,7 @@ def test_arm_postprocess_call():
 
 def test_arm_postprocess_ret():
 
-    for i in xrange(3):
+    for i in range(3):
         # e91ba8f0
         # ldmdb  R11, {R4,R11,SP,PC}
         irsb = pyvex.IRSB(data=b'\xe9\x1b\xa8\xf0',


### PR DESCRIPTION
As the module is designed for python 3 only, there is no need to keep xrange use and __future__.print_function import.