### PR TITLE
Type Annotations for pyvex

### DIFF
--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -14,6 +14,7 @@ import sys
 import cffi
 import pkg_resources
 RegisterOffset = NewType('RegisterOffset', int)
+TmpVar = NewType('TmpVar', int)
 from .vex_ffi import ffi_str as _ffi_str
 ffi = cffi.FFI()
 

--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -2,6 +2,7 @@
 PyVEX provides an interface that translates binary code into the VEX intermediate represenation (IR).
 For an introduction to VEX, take a look here: https://docs.angr.io/advanced-topics/ir
 """
+from typing import NewType, Any
 
 __version__ = (8, 20, 1, 7)
 
@@ -12,10 +13,9 @@ import os
 import sys
 import cffi
 import pkg_resources
-
+RegisterOffset = NewType('RegisterOffset', int)
 from .vex_ffi import ffi_str as _ffi_str
 ffi = cffi.FFI()
-
 
 import logging
 logging.getLogger("pyvex").addHandler(logging.NullHandler())
@@ -40,7 +40,7 @@ def _find_c_lib():
     dir(lib)
     return lib
 
-pvc = _find_c_lib()
+pvc = _find_c_lib() # type: Any # This should be properly typed, but this seems non trivial
 
 # pylint: disable=wildcard-import
 from .enums import *

--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -13,9 +13,6 @@ import os
 import sys
 import cffi
 import pkg_resources
-RegisterOffset = NewType('RegisterOffset', int)
-RegisterName = NewType('RegisterName', str)
-TmpVar = NewType('TmpVar', int)
 from .vex_ffi import ffi_str as _ffi_str
 ffi = cffi.FFI()
 

--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -14,6 +14,7 @@ import sys
 import cffi
 import pkg_resources
 RegisterOffset = NewType('RegisterOffset', int)
+RegisterName = NewType('RegisterName', str)
 TmpVar = NewType('TmpVar', int)
 from .vex_ffi import ffi_str as _ffi_str
 ffi = cffi.FFI()

--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -1,6 +1,10 @@
 import copy
 import sys
 import itertools
+from typing import List, Optional
+
+from pyvex.expr import IRExpr
+from pyvex.stmt import IRStmt
 
 from . import VEXObject
 from . import expr, stmt
@@ -83,10 +87,10 @@ class IRSB(VEXObject):
         self.addr = mem_addr
         self.arch = arch
 
-        self.statements = []
-        self.next = None
+        self.statements = [] # type: List[IRStmt]
+        self.next = None # type: Optional[IRExpr]
         self._tyenv = None
-        self.jumpkind = None
+        self.jumpkind = None # type: Optional[str]
         self._direct_next = None
         self._size = None
         self._instructions = None

--- a/pyvex/const.py
+++ b/pyvex/const.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional, List
 
 from . import VEXObject, ffi, pvc
 from .enums import get_enum_from_int
@@ -10,8 +11,8 @@ class IRConst(VEXObject):
 
     __slots__ = ['_value']
 
-    type = None
-    tag = None
+    type = None # type: Optional[str]
+    tag = None # type: Optional[str]
     c_constructor = None
 
     def pp(self):
@@ -22,7 +23,7 @@ class IRConst(VEXObject):
         return get_type_size(self.type)
 
     @property
-    def value(self):
+    def value(self) -> int:
         return self._value
 
     @staticmethod
@@ -51,7 +52,7 @@ class IRConst(VEXObject):
 
 
 class U1(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_I1'
     tag = 'Ico_U1'
@@ -70,7 +71,7 @@ class U1(IRConst):
 
 
 class U8(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_I8'
     tag = 'Ico_U8'
@@ -92,7 +93,7 @@ _U8_POOL = [ U8(i) for i in range(256) ]
 
 
 class U16(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_I16'
     tag = 'Ico_U16'
@@ -119,14 +120,14 @@ _U16_POOL = [ U16(i) for i in range(1024) ] + [ U16(i) for i in range(0xfc00, 0x
 
 
 class U32(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_I32'
     tag = 'Ico_U32'
     op_format = '32'
     c_constructor = pvc.IRConst_U32
 
-    def __init__(self, value):
+    def __init__(self, value: int):
         self._value = value
 
     def __str__(self):
@@ -146,7 +147,7 @@ _U32_POOL = [ U32(i) for i in range(1024) ] + [ U32(i) for i in range(0xfffffc00
 
 
 class U64(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_I64'
     tag = 'Ico_U64'
@@ -197,7 +198,7 @@ def vex_int_class(size):
 
 
 class F32(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_F32'
     tag = 'Ico_F32'
@@ -216,7 +217,7 @@ class F32(IRConst):
 
 
 class F32i(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_F32'
     tag = 'Ico_F32i'
@@ -235,7 +236,7 @@ class F32i(IRConst):
 
 
 class F64(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_F64'
     tag = 'Ico_F64'
@@ -254,7 +255,7 @@ class F64(IRConst):
 
 
 class F64i(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_F64'
     tag = 'Ico_F64i'
@@ -273,7 +274,7 @@ class F64i(IRConst):
 
 
 class V128(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_V128'
     tag = 'Ico_V128'
@@ -299,7 +300,7 @@ class V128(IRConst):
 
 
 class V256(IRConst):
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
     type = 'Ity_V256'
     tag = 'Ico_V256'

--- a/pyvex/enums.py
+++ b/pyvex/enums.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from . import pvc, ffi
 
 
@@ -6,7 +8,7 @@ class VEXObject:
     The base class for Vex types.
     """
 
-    __slots__ = [ ]
+    __slots__ = [ ] # type: List
 
 
 class IRCallee(VEXObject):

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -3,7 +3,8 @@ import logging
 from typing import List, Optional
 
 
-from . import VEXObject, RegisterOffset, TmpVar
+from . import VEXObject
+from archinfo import RegisterOffset, TmpVar
 from .enums import IRCallee, IRRegArray, get_int_from_enum, get_enum_from_int
 from .const import get_type_size, U8, U16, U32, U64
 

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -3,14 +3,12 @@ import logging
 from typing import List, Optional, NewType
 
 
-from . import VEXObject
+from . import VEXObject, RegisterOffset, TmpVar
 from .enums import IRCallee, IRRegArray, get_int_from_enum, get_enum_from_int
 from .const import get_type_size, U8, U16, U32, U64, IRConst
 
 l = logging.getLogger("pyvex.expr")
 
-TmpVar = NewType('TmpVar', int)
-RegisterOffset = NewType('RegisterOffset', int)
 
 
 class IRExpr(VEXObject):
@@ -604,14 +602,14 @@ class Const(IRExpr):
 
     tag = 'Iex_Const'
 
-    def __init__(self, con: IRConst):
+    def __init__(self, con: 'IRConst'):
         self._con = con
 
     def __str__(self):
         return str(self.con)
 
     @property
-    def con(self) -> IRConst:
+    def con(self) -> 'IRConst':
         return self._con
 
     @staticmethod

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -1,11 +1,11 @@
 import re
 import logging
-from typing import List, Optional, NewType
+from typing import List, Optional
 
 
 from . import VEXObject, RegisterOffset, TmpVar
 from .enums import IRCallee, IRRegArray, get_int_from_enum, get_enum_from_int
-from .const import get_type_size, U8, U16, U32, U64, IRConst
+from .const import get_type_size, U8, U16, U32, U64
 
 l = logging.getLogger("pyvex.expr")
 

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -91,7 +91,7 @@ class IRExpr(VEXObject):
                 v.replace_expression(expr, replacement)
 
     @staticmethod
-    def _from_c(c_expr):
+    def _from_c(c_expr) -> 'IRExpr':
         if c_expr == ffi.NULL or c_expr[0] == ffi.NULL:
             return None
 

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -278,7 +278,7 @@ class Get(IRExpr):
 
     tag = 'Iex_Get'
 
-    def __init__(self, offset: RegisterOffset, ty):
+    def __init__(self, offset: RegisterOffset, ty: str):
         self.offset = offset
         self.ty = ty
 

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -1,11 +1,16 @@
 import re
 import logging
+from typing import List, Optional, NewType
+
 
 from . import VEXObject
 from .enums import IRCallee, IRRegArray, get_int_from_enum, get_enum_from_int
-from .const import get_type_size, U8, U16, U32, U64
+from .const import get_type_size, U8, U16, U32, U64, IRConst
 
 l = logging.getLogger("pyvex.expr")
+
+TmpVar = NewType('TmpVar', int)
+RegisterOffset = NewType('RegisterOffset', int)
 
 
 class IRExpr(VEXObject):
@@ -15,14 +20,14 @@ class IRExpr(VEXObject):
 
     __slots__ = [ ]
 
-    tag = None
+    tag = None # type: Optional[str]
     tag_int = 0  # set automatically at bottom of file
 
     def pp(self):
         print(self.__str__())
 
     @property
-    def child_expressions(self):
+    def child_expressions(self) -> List['IRExpr']:
         """
         A list of all of the expressions that this expression ends up evaluating.
         """
@@ -229,14 +234,14 @@ class RdTmp(IRExpr):
 
     tag = 'Iex_RdTmp'
 
-    def __init__(self, tmp):
+    def __init__(self, tmp: TmpVar):
         self._tmp = tmp
 
     def __str__(self):
         return "t%d" % self.tmp
 
     @property
-    def tmp(self):
+    def tmp(self) -> TmpVar:
         return self._tmp
 
     @staticmethod
@@ -275,7 +280,7 @@ class Get(IRExpr):
 
     tag = 'Iex_Get'
 
-    def __init__(self, offset, ty):
+    def __init__(self, offset: RegisterOffset, ty):
         self.offset = offset
         self.ty = ty
 
@@ -599,14 +604,14 @@ class Const(IRExpr):
 
     tag = 'Iex_Const'
 
-    def __init__(self, con):
+    def __init__(self, con: IRConst):
         self._con = con
 
     def __str__(self):
         return str(self.con)
 
     @property
-    def con(self):
+    def con(self) -> IRConst:
         return self._con
 
     @staticmethod

--- a/pyvex/py.typed
+++ b/pyvex/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -1,10 +1,9 @@
 import logging
-from typing import NewType, Iterable, Iterator, Optional
+from typing import Iterator, Optional
 
 from . import VEXObject, RegisterOffset, TmpVar
 from .enums import get_enum_from_int, get_int_from_enum
 
-from .expr import IRExpr
 l = logging.getLogger('pyvex.stmt')
 
 
@@ -23,7 +22,7 @@ class IRStmt(VEXObject):
         print(self.__str__())
 
     @property
-    def expressions(self) -> Iterator[IRExpr]:
+    def expressions(self) -> Iterator['IRExpr']:
         for k in self.__slots__:
             v = getattr(self, k)
             if isinstance(v, IRExpr):
@@ -158,7 +157,7 @@ class Put(IRStmt):
 
     tag = 'Ist_Put'
 
-    def __init__(self, data: IRExpr, offset: RegisterOffset):
+    def __init__(self, data: 'IRExpr', offset: RegisterOffset):
         self.data = data
         self.offset = offset
 
@@ -226,7 +225,7 @@ class WrTmp(IRStmt):
 
     tag = 'Ist_WrTmp'
 
-    def __init__(self, tmp: TmpVar, data: IRExpr):
+    def __init__(self, tmp: TmpVar, data: 'IRExpr'):
         self.tmp = tmp
         self.data = data
 
@@ -265,7 +264,7 @@ class Store(IRStmt):
 
     tag = 'Ist_Store'
 
-    def __init__(self, addr: IRExpr, data: IRExpr, end: str):
+    def __init__(self, addr: 'IRExpr', data: 'IRExpr', end: str):
         self.addr = addr
         self.data = data
         self.end = end
@@ -704,7 +703,7 @@ def enum_to_stmt_class(tag_enum):
         raise KeyError('No statement class for tag %s.' % get_enum_from_int((tag_enum)))
 
 
-from .expr import IRExpr, Get, IRExpr, IRExpr
+from .expr import IRExpr, Get
 from .const import IRConst
 from .enums import IRRegArray, IRCallee
 from .errors import PyVEXError

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -1,14 +1,13 @@
 import logging
 from typing import NewType, Iterable, Iterator, Optional
 
-from . import VEXObject, RegisterOffset
+from . import VEXObject, RegisterOffset, TmpVar
 from .enums import get_enum_from_int, get_int_from_enum
 
 from .expr import IRExpr
 l = logging.getLogger('pyvex.stmt')
 
 
-TmpVar = NewType('TmpVar', int)
 
 class IRStmt(VEXObject):
     """

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -1,7 +1,8 @@
 import logging
 from typing import Iterator, Optional
 
-from . import VEXObject, RegisterOffset, TmpVar
+from . import VEXObject
+from archinfo import RegisterOffset, TmpVar
 from .enums import get_enum_from_int, get_int_from_enum
 
 l = logging.getLogger('pyvex.stmt')

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -265,7 +265,7 @@ class Store(IRStmt):
 
     tag = 'Ist_Store'
 
-    def __init__(self, addr: IRExpr, data: IRExpr, end):
+    def __init__(self, addr: IRExpr, data: IRExpr, end: str):
         self.addr = addr
         self.data = data
         self.end = end

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -1,17 +1,21 @@
 import logging
+from typing import NewType, Iterable, Iterator, Optional
 
-from . import VEXObject
+from . import VEXObject, RegisterOffset
 from .enums import get_enum_from_int, get_int_from_enum
 
+from .expr import IRExpr
 l = logging.getLogger('pyvex.stmt')
 
+
+TmpVar = NewType('TmpVar', int)
 
 class IRStmt(VEXObject):
     """
     IR statements in VEX represents operations with side-effects.
     """
 
-    tag = None
+    tag = None # type: Optional[str]
     tag_int = 0  # set automatically at bottom of file
 
     __slots__ = [ ]
@@ -20,7 +24,7 @@ class IRStmt(VEXObject):
         print(self.__str__())
 
     @property
-    def expressions(self):
+    def expressions(self) -> Iterator[IRExpr]:
         for k in self.__slots__:
             v = getattr(self, k)
             if isinstance(v, IRExpr):
@@ -108,7 +112,7 @@ class IMark(IRStmt):
 
     tag = 'Ist_IMark'
 
-    def __init__(self, addr, length, delta):
+    def __init__(self, addr: int, length: int, delta: int):
         self.addr = addr
         self.len = length
         self.delta = delta
@@ -155,7 +159,7 @@ class Put(IRStmt):
 
     tag = 'Ist_Put'
 
-    def __init__(self, data, offset):
+    def __init__(self, data: IRExpr, offset: RegisterOffset):
         self.data = data
         self.offset = offset
 
@@ -223,7 +227,7 @@ class WrTmp(IRStmt):
 
     tag = 'Ist_WrTmp'
 
-    def __init__(self, tmp, data):
+    def __init__(self, tmp: TmpVar, data: IRExpr):
         self.tmp = tmp
         self.data = data
 
@@ -701,7 +705,7 @@ def enum_to_stmt_class(tag_enum):
         raise KeyError('No statement class for tag %s.' % get_enum_from_int((tag_enum)))
 
 
-from .expr import IRExpr, Get
+from .expr import IRExpr, Get, IRExpr, IRExpr
 from .const import IRConst
 from .enums import IRRegArray, IRCallee
 from .errors import PyVEXError

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -265,7 +265,7 @@ class Store(IRStmt):
 
     tag = 'Ist_Store'
 
-    def __init__(self, addr, data, end):
+    def __init__(self, addr: IRExpr, data: IRExpr, end):
         self.addr = addr
         self.data = data
         self.end = end

--- a/setup.py
+++ b/setup.py
@@ -206,6 +206,6 @@ setup(
     setup_requires=[ 'pycparser', 'cffi>=1.0.3' ],
     include_package_data=True,
     package_data={
-        'pyvex': ['lib/*', 'include/*']
+        'pyvex': ['lib/*', 'include/*', 'py.typed']
     }
 )


### PR DESCRIPTION
Initial effort to add type annotation to the angr project. This should have no effect on runtime behavior, but makes developing pyvex and anything that uses it easier. At least for the project I am currently working on.

This can be merged incrementally, for now this is WIP until I have at least covered the annotations that I need to statically type another poject. PEP 561 explicitly allows a package that is only partially typed. 