### PR TITLE
Add @rpath to the library install name on macOS

### DIFF
--- a/pyvex_c/Makefile
+++ b/pyvex_c/Makefile
@@ -2,7 +2,7 @@ UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 	LIBRARY_FILE=libpyvex.dylib
 	STATIC_LIBRARY_FILE=libpyvex.a
-	LDFLAGS=-Wl,-install_name,$(LIBRARY_FILE)
+	LDFLAGS=-Wl,-install_name,@rpath/$(LIBRARY_FILE)
 endif
 ifeq ($(UNAME), Linux)
 	LIBRARY_FILE=libpyvex.so


### PR DESCRIPTION
This makes it possible for angr to link against libpyvex.dylib more easily on macOS. For context on why this change would be useful, see https://github.com/angr/angr/pull/1932.