### PR TITLE
Fixes VS2019 Build Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def _build_vex():
     e['MULTIARCH'] = '1'
     e['DEBUG'] = '1'
 
-    cmd1 = ['nmake', '/f', 'Makefile-msvc', 'all']
+    cmd1 = ['nmake', '/f', 'Makefile-msvc', r'pub\libvex_guest_offsets.h', 'all']
     cmd2 = ['make', '-f', 'Makefile-gcc', '-j', str(multiprocessing.cpu_count()), 'all']
     cmd3 = ['gmake', '-f', 'Makefile-gcc', '-j', str(multiprocessing.cpu_count()), 'all']
     for cmd in (cmd1, cmd2, cmd3):


### PR DESCRIPTION
When attempting to build pyvex with VS2019, the compilation process was throwing an error about not having `pub\libvex_guest_offsets.h`. As it turns out, vex doesn't by default generate that file. The command to do so is in the makefile but needs to be run. This is why build is failing on msvc.