### PR TITLE
Implemented tMRS/tMSR spotters

### DIFF
--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -4,7 +4,7 @@ For an introduction to VEX, take a look here: https://docs.angr.io/advanced-topi
 """
 from typing import NewType, Any
 
-__version__ = (8, 20, 7, 27)
+__version__ = (9, 0, "gitrolling")
 
 if bytes is str:
     raise Exception("This module is designed for python 3 only. Please install an older version to use python 2.")

--- a/pyvex/lifting/gym/arm_spotter.py
+++ b/pyvex/lifting/gym/arm_spotter.py
@@ -263,7 +263,7 @@ class Instruction_tCPSID(ThumbInstruction):
         l.debug("[thumb] Ignoring CPS instruction at %#x.", self.addr)
 
 class Instruction_tMSR(ThumbInstruction):
-    name = 'MSR'
+    name = 'tMSR'
     bin_format = '10x0mmmmxxxxxxxx11110011100Rrrrr'
 
     def compute_result(self): # pylint: disable=arguments-differ
@@ -279,13 +279,13 @@ class Instruction_tMSR(ThumbInstruction):
                 src = self.get(src_reg, Type.int_32)
                 self.put(src, 'primask')
             else:
-               l.warning("[thumb] MSR at %#x is writing into an unsupported special register %#x. Ignoring the instruction. FixMe.", self.addr, dest_spec_reg)
+               l.warning("[thumb] tMSR at %#x is writing into an unsupported special register %#x. Ignoring the instruction. FixMe.", self.addr, dest_spec_reg)
         else:
-            l.warning("[thumb] MSR at %#x is writing SPSR. Ignoring the instruction. FixMe.", self.addr)
-        l.warning("[thumb] Spotting an MSR instruction at %#x.  This is not fully tested.  Prepare for errors." , self.addr)
+            l.warning("[thumb] tMSR at %#x is writing SPSR. Ignoring the instruction. FixMe.", self.addr)
+        l.warning("[thumb] Spotting an tMSR instruction at %#x.  This is not fully tested.  Prepare for errors." , self.addr)
 
 class Instruction_tMRS(ThumbInstruction):
-    name = 'MRS'
+    name = 'tMRS'
     bin_format = '10x0mmmmxxxxxxxx11110011111Rrrrr'
 
     def compute_result(self): # pylint: disable=arguments-differ
@@ -305,11 +305,11 @@ class Instruction_tMRS(ThumbInstruction):
                 src = self.get("primask", Type.int_32)
                 self.put(src, dest_reg)
             else:
-                l.warning("[thumb] MRS at %#x is using the unsupported special register %#x. Ignoring the instruction. FixMe." , self.addr, spec_reg)
+                l.warning("[thumb] tMRS at %#x is using the unsupported special register %#x. Ignoring the instruction. FixMe." , self.addr, spec_reg)
         else:
-            l.warning("[thumb] MRS at %#x is reading from SPSR. Ignoring the instruction. FixMe." , self.addr)
-            l.debug("[thumb] Ignoring MRS instruction at %#x.", self.addr)
-        l.warning("[thumb] Spotting an MRS instruction at %#x.  This is not fully tested.  Prepare for errors." , self.addr)
+            l.warning("[thumb] tMRS at %#x is reading from SPSR. Ignoring the instruction. FixMe." , self.addr)
+            l.debug("[thumb] Ignoring tMRS instruction at %#x.", self.addr)
+        l.warning("[thumb] Spotting an tMRS instruction at %#x.  This is not fully tested.  Prepare for errors." , self.addr)
 
 class Instruction_tDMB(ThumbInstruction):
     name = 'DMB'

--- a/pyvex/lifting/util/irsb_postprocess.py
+++ b/pyvex/lifting/util/irsb_postprocess.py
@@ -1,3 +1,4 @@
+from typing import Optional
 
 from ...block import IRSB
 from ...stmt import WrTmp, Put, IMark, Store, NoOp
@@ -18,15 +19,12 @@ def _flatten_and_get_expr(irsb_old, irsb_c, old_to_new_tmp, expr):
         return RdTmp.get_instance(irsb_c.mktmp(expr.__class__(expr.op, expr_args)))
 
 
-def irsb_postproc_flatten(irsb_old, irsb_new=None):
+def irsb_postproc_flatten(irsb_old: IRSB, irsb_new: Optional[IRSB]=None) -> IRSB:
     """
 
     :param irsb_old: The IRSB to be flattened
-    :type irsb_old: IRSB
     :param irsb_new: the IRSB to rewrite the instructions of irsb_old to. If it is None a new empty IRSB will be created
-    :type irsb_new: IRSB
     :return: the flattened IRSB
-    :rtype: IRSB
     """
     irsb_new = irsb_new if irsb_new is not None else IRSB(None, irsb_old.addr, irsb_old.arch)
     irsb_c = IRSBCustomizer(irsb_new)

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
         sys.argv.append(name.replace('.', '_').replace('-', '_'))
 
 setup(
-    name="pyvex", version='8.20.7.27', description="A Python interface to libVEX and VEX IR",
+    name="pyvex", version='9.0.gitrolling', description="A Python interface to libVEX and VEX IR",
     python_requires='>=3.6',
     url='https://github.com/angr/pyvex',
     packages=packages,
@@ -199,7 +199,7 @@ setup(
     install_requires=[
         'pycparser',
         'cffi>=1.0.3',
-        'archinfo==8.20.7.27',
+        'archinfo==9.0.gitrolling',
         'bitstring',
         'future',
     ],

--- a/tests/test_spotter.py
+++ b/tests/test_spotter.py
@@ -114,7 +114,8 @@ def test_tmsr():
     nose.tools.assert_equal(type(b.statements[1].data),pyvex.expr.Get)
     nose.tools.assert_equal(p.arch.register_names.get(b.statements[1].data.offset , ''),"r2")
     nose.tools.assert_equal(type(b.statements[2]),pyvex.stmt.Put)
-    
+
+
 if __name__ == '__main__':
     test_basic()
     test_embedded()


### PR DESCRIPTION
This is the spotter for the tMRS instruction.
Before merging, 2 quick questions:

1. Maybe there is a better way to refer to the SP in that `self.get(13, Type.int_32)` instead of hardcoding the index in the register list?

2. As for now, I've implemented only the minimum checks I need for my analysis, do we want to start to organize `archinfo` with the information regarding ALL the special registers we are missing or it is too early for this? (See https://github.com/aquynh/capstone/blob/45bec1a691e455b864f7e4d394711a467e5493dc/arch/ARM/ARMInstPrinter.c#L1654)