### PR TITLE
Call type.__getattr__ in metaclass TypeMeta instead of defaulting to None

### DIFF
--- a/pyvex/lifting/util/vex_helper.py
+++ b/pyvex/lifting/util/vex_helper.py
@@ -28,6 +28,8 @@ class TypeMeta(type):
         if match:
             width = int(match.group('size'))
             return vex_int_class(width).type
+        else:
+            return type.__getattr__(name)
 
 class Type(with_metaclass(TypeMeta, object)):
     __metaclass__ = TypeMeta


### PR DESCRIPTION
This actually cases sphinx doc generation to fail, as it calls `hasattr(o, __orig_bases__)`. `TypeMeta` would end up returning `True` because `getattr` would return `None` instead of raising an exception, and this breaks assumptions made about Python `type` objects in Sphinx because `None` is not considered a valid value for `type.__orig_bases__`.