### PR TITLE
Pin bitstring to <3.1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ setup(
         'pycparser',
         'cffi>=1.0.3',
         'archinfo==9.0.gitrolling',
-        'bitstring',
+        'bitstring<3.1.8',
         'future',
     ],
     setup_requires=[ 'pycparser', 'cffi>=1.0.3' ],


### PR DESCRIPTION
Example failure caused by 3.1.8:
```

--------------------- >> end captured stdout << ----------------------
======================================================================
ERROR: test_decompiler.test_decompiling_aes_armel
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/1/s/build/virtualenv/lib/python3.6/site-packages/bitstring.py", line 2098, in _readtoken
    val = name_to_read[name](self, length, pos)
KeyError: 'uintle'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/1/s/build/src/angr/tests/test_decompiler.py", line 79, in test_decompiling_aes_armel
    p = angr.Project(bin_path, arch='ARMEL', auto_load_libs=False, load_debug_info=True)
  File "/__w/1/s/build/src/angr/angr/project.py", line 134, in __init__
    self.loader = cle.Loader(self.filename, concrete_target=concrete_target, **load_options)
  File "/__w/1/s/build/src/cle/cle/loader.py", line 138, in __init__
    self.initial_load_objects = self._internal_load(main_binary, *preload_libs, *force_load_libs, preloading=(main_binary, *preload_libs))
  File "/__w/1/s/build/src/cle/cle/loader.py", line 667, in _internal_load
    obj = self._load_object_isolated(main_spec)
  File "/__w/1/s/build/src/cle/cle/loader.py", line 849, in _load_object_isolated
    result = backend_cls(binary, binary_stream, is_main_bin=self.main_object is None, loader=self, **options)
  File "/__w/1/s/build/src/cle/cle/backends/elf/elf.py", line 179, in __init__
    self._load_plt()
  File "/__w/1/s/build/src/cle/cle/backends/elf/metaelf.py", line 292, in _load_plt
    bb = self._block(addr, skip_stmts=True)
  File "/__w/1/s/build/src/cle/cle/backends/elf/metaelf.py", line 68, in _block
    return pyvex.IRSB(dat, addr, self.arch, bytes_offset=1 if thumb else 0, opt_level=1, skip_stmts=skip_stmts)
  File "/__w/1/s/build/src/pyvex/pyvex/block.py", line 115, in __init__
    cross_insn_opt=cross_insn_opt,
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/__init__.py", line 109, in lift
    collect_data_refs, cross_insn_opt=cross_insn_opt,
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/lifter.py", line 80, in _lift
    self.lift()
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/gym/arm_spotter.py", line 399, in lift
    super().lift(disassemble, dump_irsb)
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/util/lifter_helper.py", line 96, in lift
    instructions = self.decode()
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/util/lifter_helper.py", line 80, in decode
    instr = self._decode_next_instruction(addr)
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/util/lifter_helper.py", line 53, in _decode_next_instruction
    return possible_instr(self.bitstrm, self.irsb.arch, addr)
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/util/instr_helper.py", line 80, in __init__
    self.data = self.parse(bitstrm)
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/util/instr_helper.py", line 167, in parse
    instr_bits = self._load_le_instr(bitstrm, numbits)
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/gym/arm_spotter.py", line 111, in _load_le_instr
    return super()._load_le_instr(bitstream, numbits)
  File "/__w/1/s/build/src/pyvex/pyvex/lifting/util/instr_helper.py", line 380, in _load_le_instr
    return bitstring.Bits(uint=bitstream.peek("uintle:%d" % numbits), length=numbits).bin
  File "/__w/1/s/build/virtualenv/lib/python3.6/site-packages/bitstring.py", line 4015, in peek
    value = self.read(fmt)
  File "/__w/1/s/build/virtualenv/lib/python3.6/site-packages/bitstring.py", line 3952, in read
    value, self._pos = self._readtoken(name, self._pos, length)
  File "/__w/1/s/build/virtualenv/lib/python3.6/site-packages/bitstring.py", line 2103, in _readtoken
    raise ValueError("Can't parse token {0}:{1}".format(name, length))
ValueError: Can't parse token uintle:32
```