### PR TITLE
Unpin bitstring

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ setup(
         'pycparser',
         'cffi>=1.0.3',
         'archinfo==9.0.gitrolling',
-        'bitstring<3.1.8',
+        'bitstring',
         'future',
     ],
     setup_requires=[ 'pycparser', 'cffi>=1.0.3' ],


### PR DESCRIPTION
This follows up #235, 3.1.8 has been yanked and a 3.1.9 has been released.