### PR TITLE
Add the line to let pyvex support ppc64

### DIFF
--- a/pyvex_c/pyvex.c
+++ b/pyvex_c/pyvex.c
@@ -173,6 +173,8 @@ int vex_init() {
 #elif __s390x__
 	vta.arch_host = VexArchS390X;
 	vai_host.hwcaps = VEX_HWCAPS_S390X_LDISP;
+#elif defined(__powerpc__)
+        vta.arch_host = VexArchPPC64;
 #else
 #error "Unsupported host arch"
 #endif


### PR DESCRIPTION
## Problem

Pyvex does not compile on PowerPC 64 (ppc64) hosts. 

This is also in response to issue #239 .

## Solution

Add an extra elif statement to set the `arch_host` to `VexArchPPC64`. All the support was there, just this was not defined.

```c
#elif defined(__powerpc__)
    vta.arch_host = VexArchPPC64;
```

## tl;dr

- Patch works, may not be inclusive of ppc32 systems.
- Important tests seemed to pass correctly.
- Pyvex tested on emulated ppc64le docker container and ppc64le host. Greater angr-dev project tested on emulated ppc64le container with success. 
- Successfully working with angr-dev environment all setup and installed on container environment.

## Possible Short comings

In the patch, I did just assume if powerpc was defined, it was probably ppc64. This may not be acceptable if there is a ppc32 machine. Downside is, there will need to be extra checks for which version since ppc64 may have the `__powerpc__` tag defined. This was noticed on the physical powerpc system which is ppc64e. 

### Potential PPC Tags:

```c
// Source: https://webcache.googleusercontent.com/search?q=cache:9c43gR_4QKcJ:https://stackoverflow.com/questions/152016/detecting-cpu-architecture-compile-time+&cd=1&hl=en&ct=clnk&gl=us&client=firefox-b-1-d
#elif defined(__powerpc) || defined(__powerpc__) || defined(__powerpc64__) || defined(__POWERPC__) || defined(__ppc__) || defined(__PPC__) || defined(_ARCH_PPC)
return "POWERPC";
#elif defined(__PPC64__) || defined(__ppc64__) || defined(_ARCH_PPC64)
return "POWERPC64";
```

## Testing

Some basic testing has been done to test if this is working or not. This was done by using the non-architecture-specific test files in pyvex/tests/. More specifically: test.py , test_lift.py. 

### Test.py

This test passed with `Ran 38 tests in 155.706s` in a pp64le docker container running on QEMU. 

On the physical ppc64le machine, a couple of the tests failed due to angr not being setup on the system. This was due to some concerns stated below in `Runtime Environments`.

### Test_lift.py

This test passed with `Ran 3 tests in 0.544s` in a pp64le docker container running on QEMU. 

This also worked on ppc64le. 

## Runtime Environments

This was tested using the angr-dev project and was able to test this working with angr. The systems this project was tested on was using a docker container specifically built for ppc64le then emulated using QEMU. I was able to test pyvex on a physical ppc64le machine however, the greater angr project was unable to be tested due to some library needs that I was not able to install on the ppc64le machine due to some permission issues (unrelated to angr, the user I was using does not have good perms). I am working on getting this resolved however, I thought I would still get the ball rolling on this. 

### Docker Runtime Setup

To use a ppc64 container on x86_64, I did the following:

```bash
# Source https://www.stereolabs.com/docs/docker/building-arm-container-on-x86/
# Install qemu deps
sudo apt-get install qemu binfmt-support qemu-user-static
# Execute the registering scripts for qemu
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
```

Then using the following dockerfile, I built the angr-dev environment (without installing the pulled repos so I could make the patches I needed). This is modeled after the Dockerfile found in angr/angr-dev:

```dockerfile
FROM ppc64le/ubuntu

ENV EBIAN_FRONTEND=noninteractive
ENV BRANCH=master
ENV TZ=Etc/UTC

RUN dpkg --add-architecture ppc64le

RUN apt update 
RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
RUN apt-get -o APT::Immediate-Configure=0 install -y \
	virtualenvwrapper python3-dev python3-pip \
	build-essential libxml2-dev libxslt1-dev git \
	libffi-dev cmake libreadline-dev libtool debootstrap \
	debian-archive-keyring libglib2.0-dev libpixman-1-dev \
	qtdeclarative5-dev binutils-multiarch nasm \
	libc6 libgcc1 libstdc++6 libtinfo5 zlib1g vim libssl-dev openjdk-8-jdk

RUN useradd -s /bin/bash -m angr

RUN su - angr -c "git clone https://github.com/Pascal-0x90/angr-dev.git -b setup/patch  && cd angr-dev && ./setup.sh -C -e angr"
RUN su - angr -c "echo 'source /usr/share/virtualenvwrapper/virtualenvwrapper.sh' >> /home/angr/.bashrc && echo 'workon angr' >> /home/angr/.bashrc"
RUN su - angr
```

The reason this specific branch of my forked angr-dev was used was because the default install script will attempt to install i386 dependencies that I could not pull properly (something something package manager). It did not seem to affect anything by just installing the defaults for this arch. 

https://github.com/Pascal-0x90/angr-dev/commit/55da57debb085608902745a92432c9232bd125ed