### PR TITLE
Fix issues during isolated build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=59", "wheel"]
+requires = ["setuptools>=59", "wheel", "cffi >= 1.0.3", "pycparser"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,6 @@ long_description = file: README.md
 
 [options]
 python_requires = >= 3.6
-setup_requires =
-    cffi >= 1.0.3; implementation_name == 'cpython'
-    pycparser
 install_requires =
     archinfo == 9.2.0.dev0
     bitstring

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,10 @@ import sys
 import shutil
 import glob
 import multiprocessing
+from distutils.command.build import build as st_build
 
 from setuptools import setup
-from distutils.command.build import build as st_build
+from setuptools.command.develop import develop as st_develop
 from setuptools.command.sdist import sdist as st_sdist
 from setuptools.errors import LibError
 
@@ -101,6 +102,11 @@ class build(st_build):
         self.execute(_build_ffi, (), msg="Creating CFFI defs file")
         super().run(*args)
 
+class develop(st_develop):
+    def run(self):
+        self.run_command("build")
+        super().run()
+
 class sdist(st_sdist):
     def run(self, *args):
         self.execute(_clean_bins, (), msg="Removing binaries")
@@ -108,6 +114,7 @@ class sdist(st_sdist):
 
 cmdclass = {
     'build': build,
+    'develop': develop,
     'sdist': sdist,
 }
 


### PR DESCRIPTION
- setup_requires in setup.cfg is ignored in PEP 517 builds
- `.` is not included in `sys.path` in PEP 517 builds
- `build_ext` is not run on every build invocation. `distutils` should stay around post py3.12 if setuptools is installed, so reverting to distutils build cmd is the best solution for now
- setuptools' `develop` only calls `build_ext`, but not `build`