### PR TITLE
Do expression replacements all at once rather than one at a time

### DIFF
--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -223,8 +223,7 @@ class IRSB(VEXObject):
                 replacement = convert_expr(expr_)
                 if replacement is not expr_:
                     to_replace[expr_] = replacement
-            for expr_, replacement in to_replace.items():
-                stmt_.replace_expression(expr_, replacement)
+            stmt_.replace_expression(to_replace)
             # Add the converted statement to self.statements
             self.statements.append(stmt_)
         extendwith.next = convert_expr(extendwith.next)

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -257,7 +257,7 @@ class RdTmp(IRExpr):
             return _RDTMP_POOL[tmp]
         return RdTmp(tmp)
 
-    def replace_expression(self, expr, replacement):
+    def replace_expression(self, replacements):
         # RdTmp is one of the terminal IRExprs, which cannot be replaced.
         pass
 

--- a/pyvex/expr.py
+++ b/pyvex/expr.py
@@ -57,38 +57,37 @@ class IRExpr(VEXObject):
     def result_type(self, tyenv):
         raise NotImplementedError()
 
-    def replace_expression(self, expr, replacement):
+    def replace_expression(self, replacements):
         """
         Replace child expressions in-place.
 
-        :param IRExpr expr:         The expression to look for.
-        :param IRExpr replacement:  The expression to replace with.
+        :param Dict[IRExpr, IRExpr] replacements:  A mapping from expression-to-find to expression-to-replace-with
         :return:                    None
         """
 
         for k in self.__slots__:
             v = getattr(self, k)
-            if v is expr:
-                setattr(self, k, replacement)
+            if isinstance(v, IRExpr) and v in replacements:
+                setattr(self, k, replacements.get(v))
             elif type(v) is list:
                 # Replace the instance in the list
                 for i, expr_ in enumerate(v):
-                    if expr_ is expr:
-                        v[i] = replacement
+                    if isinstance(expr_, IRExpr) and expr_ in replacements:
+                        v[i] = replacements.get(expr_)
             elif type(v) is tuple:
                 # Rebuild the tuple
                 _lst = [ ]
                 replaced = False
                 for i, expr_ in enumerate(v):
-                    if expr_ is expr:
-                        _lst.append(replacement)
+                    if isinstance(expr_, IRExpr) and expr_ in replacements:
+                        _lst.append(replacements.get(expr_))
                         replaced = True
                     else:
                         _lst.append(expr_)
                 if replaced:
                     setattr(self, k, tuple(_lst))
             elif isinstance(v, IRExpr):
-                v.replace_expression(expr, replacement)
+                v.replace_expression(replacements)
 
     @staticmethod
     def _from_c(c_expr) -> 'IRExpr':

--- a/pyvex/stmt.py
+++ b/pyvex/stmt.py
@@ -57,28 +57,27 @@ class IRStmt(VEXObject):
     def typecheck(self, tyenv): # pylint: disable=unused-argument,no-self-use
         return True
 
-    def replace_expression(self, expression, replacement):
+    def replace_expression(self, replacements):
         """
         Replace child expressions in-place.
 
-        :param IRExpr expression:         The expression to look for.
-        :param IRExpr replacement:  The expression to replace with.
+        :param Dict[IRExpr, IRExpr] replacements:  A mapping from expression-to-find to expression-to-replace-with
         :return:                    None
         """
 
         for k in self.__slots__:
             v = getattr(self, k)
-            if v is expression:
-                setattr(self, k, replacement)
+            if isinstance(v, IRExpr) and v in replacements:
+                setattr(self, k, replacements.get(v))
             elif isinstance(v, IRExpr):
-                v.replace_expression(expression, replacement)
+                v.replace_expression(replacements)
             elif type(v) is tuple:
                 # Rebuild the tuple
                 _lst = [ ]
                 replaced = False
                 for expr_ in v:
-                    if expr_ is expression:
-                        _lst.append(replacement)
+                    if isinstance(expr_, IRExpr) and expr_ in replacements:
+                        _lst.append(replacements.get(expr_))
                         replaced = True
                     else:
                         _lst.append(expr_)


### PR DESCRIPTION
Previously, we were doing replacements when extending blocks one expression at a time. Since tmps are identity-consed, this means that if you had an expression t1 + t2 and you're making the replacements [t1 -> t2, t2 -> t3], the result would be t3 + t3 instead of t2 + t3.

Closes angr/angr#3407