### PR TITLE
Log at "debug" level instead of "info"

### DIFF
--- a/pyvex/lifting/util/lifter_helper.py
+++ b/pyvex/lifting/util/lifter_helper.py
@@ -56,7 +56,7 @@ class GymratLifter(Lifter):
         # Try every instruction until one works
         for possible_instr in self.instrs:
             try:
-                log.info("Trying %s", possible_instr.name)
+                log.debug("Trying %s", possible_instr.name)
                 return possible_instr(self.bitstrm, self.irsb.arch, addr)
             # a ParserError signals that this instruction did not match
             # we need to try other instructions, so we ignore this error


### PR DESCRIPTION
We shouldn't log this kind of information at the "info" logging level. "debug" level will be more appropriate, like the other logs done in this function.