### PR TITLE
support RISC-V 64 in `pyvex.c`

### DIFF
--- a/pyvex_c/pyvex.c
+++ b/pyvex_c/pyvex.c
@@ -179,6 +179,10 @@ int vex_init() {
 #  endif
 #elif defined(__powerpc__)
         vta.arch_host = VexArchPPC64;
+#elif defined(__riscv)
+#  if defined(__riscv_xlen) && (__riscv_xlen == 64)
+	vta.arch_host = VexArchRISCV64;
+#  endif
 #else
 #error "Unsupported host arch"
 #endif


### PR DESCRIPTION
It seems that the code related to RISC-V 64 has been merged (https://github.com/angr/pyvex/pull/310, https://github.com/angr/vex/pull/54), but the corresponding macro definitions are missing in `pyvex.c`.
