### PR TITLE
Fix gymrat disasm

### DIFF
--- a/pyvex/lifting/gym/arm_spotter.py
+++ b/pyvex/lifting/gym/arm_spotter.py
@@ -415,7 +415,7 @@ class ARMSpotter(GymratLifter):
         super().__init__(*args)
         self.thumb: bool = False
 
-    def _lift(self, disassemble=False, dump_irsb=False):
+    def _lift(self):
         if self.irsb.addr & 1:
             # Thumb!
             self.instrs = self.thumb_instrs
@@ -423,4 +423,4 @@ class ARMSpotter(GymratLifter):
         else:
             self.instrs = self.arm_instrs
             self.thumb = False
-        super()._lift(disassemble, dump_irsb)
+        super()._lift()

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -60,7 +60,7 @@ class Lifter:
         collect_data_refs=False,
         cross_insn_opt=True,
         load_from_ro_regions=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Wrapper around the `_lift` method on Lifters. Should not be overridden in child classes.

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -20,7 +20,7 @@ class Lifter:
         "addr",
         "cross_insn_opt",
         "load_from_ro_regions",
-        "return_disasm",
+        "disasm",
         "dump_irsb",
     )
 
@@ -62,7 +62,7 @@ class Lifter:
         collect_data_refs=False,
         cross_insn_opt=True,
         load_from_ro_regions=False,
-        return_disasm=False,
+        disasm=False,
         dump_irsb=False,
     ):
         """
@@ -84,7 +84,7 @@ class Lifter:
         :param skip_stmts:          Should the lifter skip transferring IRStmts from C to Python.
         :param collect_data_refs:   Should the LibVEX lifter collect data references in C.
         :param cross_insn_opt:      If cross-instruction-boundary optimizations are allowed or not.
-        :param return_disasm:       Should the GymratLifter return a disassembly of the lifted block instead of an IRSB.
+        :param disasm:              Should the GymratLifter generate disassembly during lifting.
         :param dump_irsb:           Should the GymratLifter log the lifted IRSB.
         """
         irsb = IRSB.empty_block(self.arch, self.addr)
@@ -101,7 +101,7 @@ class Lifter:
         self.irsb = irsb
         self.cross_insn_opt = cross_insn_opt
         self.load_from_ro_regions = load_from_ro_regions
-        self.return_disasm = return_disasm
+        self.disasm = disasm
         self.dump_irsb = dump_irsb
         self._lift()
         return self.irsb

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -60,6 +60,7 @@ class Lifter:
         collect_data_refs=False,
         cross_insn_opt=True,
         load_from_ro_regions=False,
+        **kwargs
     ):
         """
         Wrapper around the `_lift` method on Lifters. Should not be overridden in child classes.
@@ -95,7 +96,7 @@ class Lifter:
         self.irsb = irsb
         self.cross_insn_opt = cross_insn_opt
         self.load_from_ro_regions = load_from_ro_regions
-        self._lift()
+        self._lift(**kwargs)
         return self.irsb
 
     def _lift(self):

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -62,7 +62,7 @@ class Lifter:
         load_from_ro_regions=False,
     ):
         """
-        Wrapper around the `_lift` method on Lifters. Most of the time, you should override `_lift` instead of `lift`.
+        Wrapper around the `_lift` method on Lifters. Should not be overridden in child classes.
 
         :param data:                The bytes to lift as either a python string of bytes or a cffi buffer object.
         :param bytes_offset:        The offset into `data` to start lifting at.
@@ -95,7 +95,8 @@ class Lifter:
         self.irsb = irsb
         self.cross_insn_opt = cross_insn_opt
         self.load_from_ro_regions = load_from_ro_regions
-        return self._lift()
+        self._lift()
+        return self.irsb
 
     def _lift(self):
         """

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -20,6 +20,8 @@ class Lifter:
         "addr",
         "cross_insn_opt",
         "load_from_ro_regions",
+        "return_disasm",
+        "dump_irsb",
     )
 
     """
@@ -60,6 +62,8 @@ class Lifter:
         collect_data_refs=False,
         cross_insn_opt=True,
         load_from_ro_regions=False,
+        return_disasm=False,
+        dump_irsb=False,
     ):
         """
         Wrapper around the `_lift` method on Lifters. Should not be overridden in child classes.
@@ -80,6 +84,8 @@ class Lifter:
         :param skip_stmts:          Should the lifter skip transferring IRStmts from C to Python.
         :param collect_data_refs:   Should the LibVEX lifter collect data references in C.
         :param cross_insn_opt:      If cross-instruction-boundary optimizations are allowed or not.
+        :param return_disasm:       Should the GymratLifter return a disassembly of the lifted block instead of an IRSB.
+        :param dump_irsb:           Should the GymratLifter log the lifted IRSB.
         """
         irsb = IRSB.empty_block(self.arch, self.addr)
         self.data = data
@@ -95,8 +101,9 @@ class Lifter:
         self.irsb = irsb
         self.cross_insn_opt = cross_insn_opt
         self.load_from_ro_regions = load_from_ro_regions
-        self._lift()
-        return self.irsb
+        self.return_disasm = return_disasm
+        self.dump_irsb = dump_irsb
+        return self._lift()
 
     def _lift(self):
         """

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -62,7 +62,7 @@ class Lifter:
         load_from_ro_regions=False,
     ):
         """
-        Wrapper around the `_lift` method on Lifters. Should not be overridden in child classes.
+        Wrapper around the `_lift` method on Lifters. Most of the time, you should override `_lift` instead of `lift`.
 
         :param data:                The bytes to lift as either a python string of bytes or a cffi buffer object.
         :param bytes_offset:        The offset into `data` to start lifting at.
@@ -95,8 +95,7 @@ class Lifter:
         self.irsb = irsb
         self.cross_insn_opt = cross_insn_opt
         self.load_from_ro_regions = load_from_ro_regions
-        self._lift()
-        return self.irsb
+        return self._lift()
 
     def _lift(self):
         """

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -60,7 +60,6 @@ class Lifter:
         collect_data_refs=False,
         cross_insn_opt=True,
         load_from_ro_regions=False,
-        **kwargs,
     ):
         """
         Wrapper around the `_lift` method on Lifters. Should not be overridden in child classes.
@@ -96,7 +95,7 @@ class Lifter:
         self.irsb = irsb
         self.cross_insn_opt = cross_insn_opt
         self.load_from_ro_regions = load_from_ro_regions
-        self._lift(**kwargs)
+        self._lift()
         return self.irsb
 
     def _lift(self):

--- a/pyvex/lifting/lifter.py
+++ b/pyvex/lifting/lifter.py
@@ -103,7 +103,8 @@ class Lifter:
         self.load_from_ro_regions = load_from_ro_regions
         self.return_disasm = return_disasm
         self.dump_irsb = dump_irsb
-        return self._lift()
+        self._lift()
+        return self.irsb
 
     def _lift(self):
         """

--- a/pyvex/lifting/util/lifter_helper.py
+++ b/pyvex/lifting/util/lifter_helper.py
@@ -97,7 +97,7 @@ class GymratLifter(Lifter):
             log.exception(f"Error decoding block at offset {bytepos:#x} (address {addr:#x}):")
             raise
 
-    def _lift(self, disassemble=False, dump_irsb=False):
+    def _lift(self):
         self.thedata = (
             self.data[: self.max_bytes]
             if isinstance(self.data, (bytes, bytearray, memoryview))
@@ -106,7 +106,7 @@ class GymratLifter(Lifter):
         log.debug(repr(self.thedata))
         instructions = self.decode()
 
-        if disassemble:
+        if self.return_disasm:
             return [instr.disassemble() for instr in instructions]
         self.irsb.jumpkind = JumpKind.Invalid
         irsb_c = IRSBCustomizer(self.irsb)
@@ -127,7 +127,7 @@ class GymratLifter(Lifter):
             dst_ty = vex_int_class(irsb_c.irsb.arch.bits).type
             irsb_c.irsb.next = irsb_c.mkconst(dst, dst_ty)
         log.debug(self.irsb._pp_str())
-        if dump_irsb:
+        if self.dump_irsb:
             self.irsb.pp()
         return self.irsb
 
@@ -143,4 +143,4 @@ class GymratLifter(Lifter):
         return self.errors
 
     def disassemble(self):
-        return self._lift(disassemble=True)
+        return self.lift(self.data, return_disasm=True)

--- a/pyvex/lifting/util/lifter_helper.py
+++ b/pyvex/lifting/util/lifter_helper.py
@@ -38,6 +38,7 @@ class GymratLifter(Lifter):
         "bitstrm",
         "errors",
         "thedata",
+        "disassembly",
     )
 
     REQUIRE_DATA_PY = True
@@ -48,6 +49,7 @@ class GymratLifter(Lifter):
         self.bitstrm = None
         self.errors = None
         self.thedata = None
+        self.disassembly = None
 
     def create_bitstrm(self):
         self.bitstrm = bitstring.ConstBitStream(bytes=self.thedata)
@@ -106,8 +108,8 @@ class GymratLifter(Lifter):
         log.debug(repr(self.thedata))
         instructions = self.decode()
 
-        if self.return_disasm:
-            return [instr.disassemble() for instr in instructions]
+        if self.disasm:
+            self.disassembly = [instr.disassemble() for instr in instructions]
         self.irsb.jumpkind = JumpKind.Invalid
         irsb_c = IRSBCustomizer(self.irsb)
         log.debug("Decoding complete.")
@@ -143,4 +145,6 @@ class GymratLifter(Lifter):
         return self.errors
 
     def disassemble(self):
-        return self.lift(self.data, return_disasm=True)
+        if self.disassembly is None:
+            self.lift(self.data, disasm=True)
+        return self.disassembly

--- a/pyvex/lifting/util/lifter_helper.py
+++ b/pyvex/lifting/util/lifter_helper.py
@@ -136,11 +136,11 @@ class GymratLifter(Lifter):
         insts = self.disassemble()
         for addr, name, args in insts:
             args_str = ",".join(str(a) for a in args)
-            disasstr += f"{addr:0#8x}:\t{name} {args_str}\n"
+            disasstr += f"{addr:#08x}:\t{name} {args_str}\n"
         print(disasstr)
 
     def error(self):
         return self.errors
 
     def disassemble(self):
-        return self.lift(disassemble=True)
+        return self._lift(disassemble=True)


### PR DESCRIPTION
The `disassemble()` doesn't work because `GymratLifter._lift()` doesn't receive its args, which are not passed through `Lifter.lift()`

```python
class GymratLifter(Lifter):
    ...
    def _lift(self, disassemble=False, dump_irsb=False):
```

and disasm result isn't returned from `Lifter.lift()`, which returns `self.irsb` instead of `self._lift()`:
```python
class Lifter:
    ...
    def lift(
        self,
        data,
        bytes_offset=None,
        max_bytes=None,
        max_inst=None,
        opt_level=1,
        traceflags=None,
        allow_arch_optimizations=None,
        strict_block_end=None,
        skip_stmts=False,
        collect_data_refs=False,
        cross_insn_opt=True,
        load_from_ro_regions=False,
    )
        ...
        self._lift()
        return self.irsb
```

I think `lift()` should return `IRSB` only because of its sematic, however `GymratLifter` (as well as many other code not listed here) also uses `_lift()` to return disassembly. Well, let's allow that.