### PR TITLE
Pin bitstring to <4.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    bitstring
+    bitstring<4.2.0
     cffi>=1.0.3;implementation_name == 'cpython'
 python_requires = >=3.8
 include_package_data = True


### PR DESCRIPTION
Last night, bitstring was updated and broke some of our tests. This pins the version to the last working version, and I'll open another PR unpinning it so that this isn't permanent.