### PR TITLE
syntax_wrapper: force 8-bit cst for set_bit idx

### DIFF
--- a/pyvex/lifting/util/syntax_wrapper.py
+++ b/pyvex/lifting/util/syntax_wrapper.py
@@ -6,7 +6,6 @@ from pyvex.expr import Const, IRExpr, RdTmp
 
 from .vex_helper import IRSBCustomizer, Type
 
-
 def checkparams(rhstype=None):
     def decorator(fn):
         @functools.wraps(fn)
@@ -95,7 +94,7 @@ class VexValue:
         setted = self.set_bit(idx, bval)
         self.__init__(setted.irsb_c, setted.rdt)
 
-    @checkparams()
+    @checkparams(rhstype=Type.int_8)
     @vvifyresults
     def set_bit(self, idx, bval):
         return self.irsb_c.set_bit(self.rdt, idx.rdt, bval.rdt)

--- a/pyvex/lifting/util/syntax_wrapper.py
+++ b/pyvex/lifting/util/syntax_wrapper.py
@@ -6,6 +6,7 @@ from pyvex.expr import Const, IRExpr, RdTmp
 
 from .vex_helper import IRSBCustomizer, Type
 
+
 def checkparams(rhstype=None):
     def decorator(fn):
         @functools.wraps(fn)


### PR DESCRIPTION
Fixes assertion error in vex_helper.py:

> operation needs to be well typed: Shr16(t7,0x000f)

From typecheck in expr.py:

> Second arg of Iop_Shr16 must be Ity_I8

Full backtrace for reference when executing an MSP430 program with an `RRC` instruction:

```
DEBUG    | 2024-05-07 15:00:44,141 | pyvex.lifting.util.lifter_helper | Lifting instruction rrc
DEBUG    | 2024-05-07 15:00:44,141 | pyvex.expr     | Second arg of Iop_Shr16 must be Ity_I8
Traceback (most recent call last):
  File "/home/jo/.local/lib/python3.10/site-packages/angr/factory.py", line 337, in block
    return Block(
  File "/home/jo/.local/lib/python3.10/site-packages/angr/block.py", line 202, in __init__
    vex = self._vex_engine.lift_vex(
  File "/home/jo/.local/lib/python3.10/site-packages/angr/engines/vex/lifter.py", line 258, in lift_vex
    irsb = pyvex.lift(
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/lift_function.py", line 134, in lift
    final_irsb = lifter(arch, addr).lift(
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/lifter.py", line 109, in lift
    self._lift()
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/lifter_helper.py", line 122, in _lift
    instr(irsb_c, instructions[:i], instructions[i + 1 :])
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/instr_helper.py", line 106, in __call__
    self.lift(irsb_c, past_instructions, future_instructions)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/instr_helper.py", line 133, in lift
    retval = self.compute_result(*inputs)  # pylint: disable=assignment-from-none
  File "/home/jo/.local/lib/python3.10/site-packages/angr_platforms/msp430/instrs_msp430.py", line 485, in compute_result
    src[15] = carryin
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/syntax_wrapper.py", line 94, in __setitem__
    setted = self.set_bit(idx, bval)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/syntax_wrapper.py", line 23, in inner_decorator
    return fn(self, *args, **kwargs)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/syntax_wrapper.py", line 33, in decor
    returned = f(self, *args, **kwargs)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/syntax_wrapper.py", line 100, in set_bit
    return self.irsb_c.set_bit(self.rdt, idx.rdt, bval.rdt)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/vex_helper.py", line 276, in set_bit
    currbit = self.get_bit(rdt, idx)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/vex_helper.py", line 267, in get_bit
    shifted = self.op_shr(rdt, idx)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/vex_helper.py", line 68, in <lambda>
    return lambda self, expr_a, expr_b: self.op_binary(make_format_op_generator(fstring))(expr_a, expr_b)
  File "/home/jo/.local/lib/python3.10/site-packages/pyvex/lifting/util/vex_helper.py", line 215, in instance
    assert op.typecheck(self.irsb.tyenv), msg + "\ntypes: " + str(self.irsb.tyenv)
AssertionError: operation needs to be well typed: Shr16(t7,0x000f)
types: t0:Ity_I16 t1:Ity_I16 t2:Ity_I16 t3:Ity_I16 t4:Ity_I16 t5:Ity_I16 t6:Ity_I16 t7:Ity_I16
```