### PR TITLE
ARM: Don't rewrite blcc default jumpkind

### DIFF
--- a/pyvex_c/postprocess.c
+++ b/pyvex_c/postprocess.c
@@ -237,7 +237,7 @@ void arm_post_processor_determine_calls(
 			// Fix the not-default exit
 			other_exit->Ist.Exit.jk = Ijk_Call;
 		}
-		else {
+		else if (!has_exit || other_exit->Ist.Exit.jk != Ijk_Call) {
 			//Fix the default exit
 			irsb->jumpkind = Ijk_Call;
 		}

--- a/tests/test_arm_postprocess.py
+++ b/tests/test_arm_postprocess.py
@@ -319,11 +319,12 @@ def test_arm_postprocess_call():
         # 400008  cmp     r0, r1
         # 40000c  blne    #FunctionB
         irsb = pyvex.IRSB(
-            data=bytes.fromhex('04e02de50a10a0e3010050e10100001b'),
+            data=bytes.fromhex("04e02de50a10a0e3010050e10100001b"),
             mem_addr=0x400000,
             arch=pyvex.ARCH_ARM_LE,
             num_inst=4,
-            opt_level=i)
+            opt_level=i,
+        )
         assert len(irsb.exit_statements) == 1
         assert irsb.exit_statements[0][2].jumpkind == "Ijk_Call"
         assert irsb.jumpkind == "Ijk_Boring"

--- a/tests/test_arm_postprocess.py
+++ b/tests/test_arm_postprocess.py
@@ -314,6 +314,20 @@ def test_arm_postprocess_call():
         )
         assert irsb.jumpkind == "Ijk_Call"
 
+        # 400000  str     lr, [sp,#-0x4]!
+        # 400004  mov     r1, #0xa
+        # 400008  cmp     r0, r1
+        # 40000c  blne    #FunctionB
+        irsb = pyvex.IRSB(
+            data=bytes.fromhex('04e02de50a10a0e3010050e10100001b'),
+            mem_addr=0x400000,
+            arch=pyvex.ARCH_ARM_LE,
+            num_inst=4,
+            opt_level=i)
+        assert len(irsb.exit_statements) == 1
+        assert irsb.exit_statements[0][2].jumpkind == "Ijk_Call"
+        assert irsb.jumpkind == "Ijk_Boring"
+
 
 def test_arm_postprocess_ret():
     for i in range(3):


### PR DESCRIPTION
We probably want to rethink these postprocessing heuristics. For now, don't change default jumpkind to Ijk_Call if there's already an Ijk_Call, e.g. in blcc (see test case).