### PR TITLE
fix(IRSB): removed wrong `instruction_addresses` calculaion from lift…

### DIFF
--- a/pyvex/block.py
+++ b/pyvex/block.py
@@ -1,5 +1,4 @@
 import copy
-import itertools
 import logging
 from typing import Optional
 
@@ -424,7 +423,7 @@ class IRSB(VEXObject):
                 self._instruction_addresses = ()
             else:
                 self._instruction_addresses = tuple(
-                    (s.addr + s.delta) for s in self.statements if type(s) is stmt.IMark
+                    (s.addr + s.delta) for s in self.statements if type(s) is stmt.IMark and s.len > 0
                 )
         return self._instruction_addresses
 
@@ -559,7 +558,6 @@ class IRSB(VEXObject):
         self._size = lift_r.size
         self.is_noop_block = lift_r.is_noop_block == 1
         self._instructions = lift_r.insts
-        self._instruction_addresses = tuple(itertools.islice(lift_r.inst_addrs, lift_r.insts))
 
         # Conditional exits
         exit_statements = []

--- a/tests/test_pyvex.py
+++ b/tests/test_pyvex.py
@@ -139,6 +139,15 @@ class TestPyvex(unittest.TestCase):
         irsb2.tyenv = copy.deepcopy(irsb.tyenv)
         print(irsb2.tyenv)
 
+    def test_irsb_instruction_addresses_contains_empty_imarks(self):
+        # 0x2000: MOV R0, 3
+        # 0x2004: SEV
+        # 0x2008: SEV
+        # 0x200C: MOV R1, 3
+        opcodes = b"\x03\x00\xa0\xe3\x04\xf0\x20\xe3\x04\xf0\x20\xe3\x03\x10\xa0\xe3"
+        irsb = pyvex.IRSB(data=opcodes, mem_addr=0x2000, arch=pyvex.ARCH_ARM_LE)
+        assert irsb.instruction_addresses == (0x2000, 0x2004, 0x2008, 0x200C)
+
     ##################
     ### Statements ###
     ##################


### PR DESCRIPTION
I had one of the weirds bug while using pyvex on one of my binaries, I found out that the irsb don't count addresses after empty IMark for some reason, but letting it recalcualtes it works fine.

```py
In [1]: import pyvex

# MOV R0, 0
# SEV
# SEV
# MOV R1, 3
In [2]: opcodes = b"\x03\x00\xa0\xe3\x04\xf0\x20\xe3\x04\xf0\x20\xe3\x03\x10\xa0\xe3\xfa\x0b\x00\xea"

In [3]: irsb = pyvex.IRSB(data=opcodes, mem_addr=0x2000, arch=pyvex.ARCH_ARM_LE)

In [4]: [hex(i) for i in irsb.instruction_addresses]
Out[4]: ['0x2000', '0x2004']

In [5]: irsb.pp()
IRSB {
   t0:Ity_I32 t1:Ity_I32 t2:Ity_I32

   00 | ------ IMark(0x2000, 4, 0) ------
   01 | PUT(r0) = 0x00000003
   02 | ------ IMark(0x2004, 0, 0) ------
   03 | ------ IMark(0x2004, 4, 0) ------
   04 | ------ IMark(0x2008, 4, 0) ------
   05 | ------ IMark(0x200c, 4, 0) ------
   06 | PUT(r1) = 0x00000003
   07 | ------ IMark(0x2010, 4, 0) ------
   NEXT: PUT(r15t) = 0x00005000; Ijk_Boring
}

In [6]: irsb._instruction_addresses = None

In [7]: [hex(i) for i in irsb.instruction_addresses]
Out[7]: ['0x2000', '0x2004', '0x2004', '0x2008', '0x200c', '0x2010']
```

Now I also noticed that there was multiple addresses, so I made sure only to include IMARK with `len` greater than 0. this seemed to solve the problem