### PR TITLE
pyvex_c: widen HashHW value slot to ULong (fix 64-bit guest-pointer truncation on 32-bit hosts)

### DIFF
--- a/pyvex_c/analysis.c
+++ b/pyvex_c/analysis.c
@@ -210,7 +210,7 @@ typedef
    struct {
       Bool*  inuse;
       HWord* key;
-      HWord* val;
+      ULong* val;
       Int    size;
       Int    used;
    }
@@ -223,7 +223,7 @@ static HashHW* newHHW()
    h->used   = 0;
    h->inuse  = (Bool*)malloc(h->size * sizeof(Bool));
    h->key    = (HWord*)malloc(h->size * sizeof(HWord));
-   h->val    = (HWord*)malloc(h->size * sizeof(HWord));
+   h->val    = (ULong*)malloc(h->size * sizeof(ULong));
    return h;
 }
 
@@ -238,7 +238,7 @@ static void freeHHW(HashHW* h)
 
 /* Look up key in the map. */
 
-static Bool lookupHHW(HashHW* h, /*OUT*/HWord* val, HWord key)
+static Bool lookupHHW(HashHW* h, /*OUT*/ULong* val, HWord key)
 {
    Int i;
 
@@ -255,7 +255,7 @@ static Bool lookupHHW(HashHW* h, /*OUT*/HWord* val, HWord key)
 
 /* Add key->val to the map.  Replaces any existing binding for key. */
 
-static void addToHHW(HashHW* h, HWord key, HWord val)
+static void addToHHW(HashHW* h, HWord key, ULong val)
 {
    Int i, j;
 
@@ -272,7 +272,7 @@ static void addToHHW(HashHW* h, HWord key, HWord val)
       /* Copy into arrays twice the size. */
       Bool*  inuse2 = malloc(2 * h->size * sizeof(Bool));
       HWord* key2   = malloc(2 * h->size * sizeof(HWord));
-      HWord* val2   = malloc(2 * h->size * sizeof(HWord));
+      ULong* val2   = malloc(2 * h->size * sizeof(ULong));
       for (i = j = 0; i < h->size; i++) {
          if (!h->inuse[i]) continue;
          inuse2[j] = True;
@@ -811,7 +811,7 @@ void execute_irsb(
 				case Iex_Get:
 					{
 						UInt key = mk_key_GetPut(data->Iex.Get.offset, data->Iex.Get.ty);
-						HWord val;
+						ULong val;
 						if (lookupHHW(env, &val, key) == True) {
 							tmps[stmt->Ist.WrTmp.tmp].used = 1;
 							tmps[stmt->Ist.WrTmp.tmp].value = val;

--- a/tests/test_data_refs_64bit_target.py
+++ b/tests/test_data_refs_64bit_target.py
@@ -1,0 +1,52 @@
+"""Regression test for HashHW value-slot truncation on 32-bit hosts.
+
+See pyvex_c/analysis.c::HashHW. Before the fix, the cached register
+value flowed through a `HWord` (= `unsigned long`, 32-bit on
+wasm32-emscripten and other ILP32 hosts), silently dropping the high
+32 bits of any guest pointer. The PoC below uses an AMD64 guest LEA +
+memory load to land a 64-bit pointer in the HashHW.
+
+https://github.com/angr/pyvex/issues/539
+"""
+import unittest
+
+import archinfo
+import pyvex
+
+
+class TestDataRefs64BitTarget(unittest.TestCase):
+    def test_64bit_guest_pointer_survives_hashhw_roundtrip(self):
+        # 5 AMD64 instructions, 25 bytes. The mov at +0xe loads from
+        # rdi - 4 where rdi was set by the previous lea to 0x100006324,
+        # so the load target should be 0x100006320.
+        blob = bytes.fromhex(
+            "488d3d39b0feff"        # lea rdi, [rip - 0x14fc7]
+            "bd14000000"            # mov ebp, 0x14
+            "488d542420"            # lea rdx, [rsp + 0x20]
+            "8b4ffc"                # mov ecx, dword ptr [rdi - 4]
+            "e873300100"            # call rel32
+        )
+        irsb = pyvex.lift(
+            blob,
+            0x10001B2E4,
+            archinfo.ArchAMD64(),
+            max_inst=5,
+            collect_data_refs=True,
+            opt_level=1,
+            cross_insn_opt=False,
+        )
+        sized_refs = [
+            r for r in (irsb.data_refs or [])
+            if r.ins_addr == 0x10001B2F5 and r.data_size == 4
+        ]
+        assert sized_refs, "expected one size=4 ref from `mov ecx, [rdi - 4]`"
+        self.assertEqual(
+            sized_refs[0].data_addr,
+            0x100006320,
+            f"data_addr=0x{sized_refs[0].data_addr:x}; "
+            "high 32 bits dropped — see pyvex_c/analysis.c HashHW value width",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data_refs_64bit_target.py
+++ b/tests/test_data_refs_64bit_target.py
@@ -11,12 +11,12 @@ https://github.com/angr/pyvex/issues/539
 
 import unittest
 
-import archinfo
-
 import pyvex
 
 
 class TestDataRefs64BitTarget(unittest.TestCase):
+    """Regression tests for HashHW value-slot width on 32-bit hosts."""
+
     def test_64bit_guest_pointer_survives_hashhw_roundtrip(self):
         # 5 AMD64 instructions, 25 bytes. The mov at +0xe loads from
         # rdi - 4 where rdi was set by the previous lea to 0x100006324,
@@ -31,7 +31,7 @@ class TestDataRefs64BitTarget(unittest.TestCase):
         irsb = pyvex.lift(
             blob,
             0x10001B2E4,
-            archinfo.ArchAMD64(),
+            pyvex.ARCH_AMD64,
             max_inst=5,
             collect_data_refs=True,
             opt_level=1,

--- a/tests/test_data_refs_64bit_target.py
+++ b/tests/test_data_refs_64bit_target.py
@@ -8,9 +8,11 @@ memory load to land a 64-bit pointer in the HashHW.
 
 https://github.com/angr/pyvex/issues/539
 """
+
 import unittest
 
 import archinfo
+
 import pyvex
 
 
@@ -20,11 +22,11 @@ class TestDataRefs64BitTarget(unittest.TestCase):
         # rdi - 4 where rdi was set by the previous lea to 0x100006324,
         # so the load target should be 0x100006320.
         blob = bytes.fromhex(
-            "488d3d39b0feff"        # lea rdi, [rip - 0x14fc7]
-            "bd14000000"            # mov ebp, 0x14
-            "488d542420"            # lea rdx, [rsp + 0x20]
-            "8b4ffc"                # mov ecx, dword ptr [rdi - 4]
-            "e873300100"            # call rel32
+            "488d3d39b0feff"  # lea rdi, [rip - 0x14fc7]
+            "bd14000000"  # mov ebp, 0x14
+            "488d542420"  # lea rdx, [rsp + 0x20]
+            "8b4ffc"  # mov ecx, dword ptr [rdi - 4]
+            "e873300100"  # call rel32
         )
         irsb = pyvex.lift(
             blob,
@@ -35,10 +37,7 @@ class TestDataRefs64BitTarget(unittest.TestCase):
             opt_level=1,
             cross_insn_opt=False,
         )
-        sized_refs = [
-            r for r in (irsb.data_refs or [])
-            if r.ins_addr == 0x10001B2F5 and r.data_size == 4
-        ]
+        sized_refs = [r for r in (irsb.data_refs or []) if r.ins_addr == 0x10001B2F5 and r.data_size == 4]
         assert sized_refs, "expected one size=4 ref from `mov ecx, [rdi - 4]`"
         self.assertEqual(
             sized_refs[0].data_addr,


### PR DESCRIPTION
Fixes #539.

## Summary

`pyvex_c/analysis.c`'s `HashHW` table — used to cache (IR-temp /
register → resolved-constant) bindings while walking an IRSB to
populate `IRSB.data_refs` — stores values as `HWord` (= `unsigned
long`, "same size as `void*` on the host", per
`vex/pub/libvex_basictypes.h:160-168`). On 64-bit `x86_64-linux-gnu`
this is 64 bits and the bug is invisible because the host width happens
to equal the AMD64 guest width. On `wasm32-emscripten`, `unsigned long`
is 32 bits but the guest stays 64-bit, so the high 32 bits of any
cached guest pointer are silently dropped. The next `lookupHHW` returns
the truncated value and `data_refs` reports the wrong `data_addr`.

The keys are pyvex-internal identifiers (IR-temp numbers, packed
register-offset/type), not pointers, so leaving them at `HWord` is
fine — only the value width matters.

## Reproduction

The downstream symptom shows up on any 64-bit PE image with
`ImageBase >= 0x1_00000000` analyzed under
`angr.analyses.CFGFast(data_references=True)` on a 32-bit host build of
pyvex. Self-contained 25-byte AMD64 PoC (see also #539):

```python
import pyvex, archinfo

# lea  rdi, [rip - 0x14fc7]      48 8d 3d 39 b0 fe ff
# mov  ebp, 0x14                 bd 14 00 00 00
# lea  rdx, [rsp + 0x20]         48 8d 54 24 20
# mov  ecx, dword ptr [rdi - 4]  8b 4f fc            <- target = 0x100006320
# call 0x10002e370               e8 73 30 01 00
BYTES = bytes.fromhex("488d3d39b0feffbd14000000488d5424208b4ffce873300100")
ADDR = 0x10001b2e4

irsb = pyvex.lift(BYTES, ADDR, archinfo.ArchAMD64(),
                  max_inst=5, collect_data_refs=True,
                  opt_level=1, cross_insn_opt=False)

[r for r in irsb.data_refs
   if r.ins_addr == 0x10001b2f5 and r.data_size == 4][0].data_addr
# x86_64-linux-gnu: 0x100006320   (correct)
# wasm32-emscripten: 0x6320       (low 32 bits of 0x100006320)
```

The previous-instruction LEA resolves `rdi = 0x100006324` correctly in
both builds (that data_ref is fine). It's the value flowing from
`tmps[].value` through `addToHHW` into the next instruction's load
resolution that gets clipped.

## Fix

Six small changes in `pyvex_c/analysis.c`:

- `HashHW.val` typed `ULong*` instead of `HWord*`.
- `newHHW` / array-resize allocations use `sizeof(ULong)`.
- `lookupHHW` out-param is `ULong*`.
- `addToHHW` value parameter is `ULong`.
- Local `HWord val` in the `Iex_Get` arm of `process_statement_for_data_refs`
  becomes `ULong val`.

The callers (`addToHHW(env, key, tmps[...].value)`,
`addToHHW(env, key, get_value_from_const_expr(...))`, etc.) already
pass `ULong` — they were being implicitly narrowed at the call site.

## Test

`tests/test_data_refs_64bit_target.py` (new) lifts the snippet above
and asserts `data_addr == 0x100006320` for the size=4 integer ref.
Passes on x86_64-linux-gnu both before and after this PR (the test
documents the expected value); the actual regression catch happens on
a 32-bit host build of pyvex. Verified manually under Pyodide 0.29.4 /
emscripten 4.0.9: `data_addr=0x6320` before, `0x100006320` after.

All 58 existing tests under `tests/` still pass.

## Compatibility

- ABI: `HashHW` is a `static` symbol in `analysis.c`; no callers
  outside this translation unit.
- Memory: 4 extra bytes per HashHW slot on 32-bit hosts. HashHW lives
  for the duration of one IRSB walk and grows powers-of-two from 8
  slots, so the overhead is negligible.
- Behavior on 64-bit hosts: unchanged (`sizeof(ULong) == sizeof(HWord)`).
