### PR TITLE
Harden the FFI parser cache against code execution (restrict unpickling)

### DIFF
--- a/pyvex/native.py
+++ b/pyvex/native.py
@@ -8,8 +8,26 @@ import tempfile
 from typing import Any
 
 import cffi
+import cffi.model
 
 from .vex_ffi import ffi_str as _ffi_str
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler for the FFI parser cache that only permits cffi.model type
+    classes. The cache legitimately contains nothing else; restricting the
+    allowed globals prevents a poisoned cache file (e.g. planted by another
+    local user in a shared temporary directory) from executing arbitrary code
+    during ``import pyvex`` (CWE-502)."""
+
+    _ALLOWED = frozenset(
+        name for name in dir(cffi.model) if isinstance(getattr(cffi.model, name), type)
+    )
+
+    def find_class(self, module, name):
+        if module == "cffi.model" and name in self._ALLOWED:
+            return getattr(cffi.model, name)
+        raise pickle.UnpicklingError(f"pyvex FFI cache: refusing to load {module}.{name}")
 
 ffi = cffi.FFI()
 
@@ -25,7 +43,7 @@ def _parse_ffi_str():
     if os.path.isfile(cache_location):
         # load the cache
         with open(cache_location, "rb") as f:
-            cache = pickle.loads(f.read())
+            cache = _RestrictedUnpickler(f).load()
         ffi._parser._declarations = cache["_declarations"]
         ffi._parser._int_constants = cache["_int_constants"]
     else:

--- a/pyvex/native.py
+++ b/pyvex/native.py
@@ -20,14 +20,13 @@ class _RestrictedUnpickler(pickle.Unpickler):
     local user in a shared temporary directory) from executing arbitrary code
     during ``import pyvex`` (CWE-502)."""
 
-    _ALLOWED = frozenset(
-        name for name in dir(cffi.model) if isinstance(getattr(cffi.model, name), type)
-    )
+    _ALLOWED = frozenset(name for name in dir(cffi.model) if isinstance(getattr(cffi.model, name), type))
 
     def find_class(self, module, name):
         if module == "cffi.model" and name in self._ALLOWED:
             return getattr(cffi.model, name)
         raise pickle.UnpicklingError(f"pyvex FFI cache: refusing to load {module}.{name}")
+
 
 ffi = cffi.FFI()
 

--- a/tests/test_ffi_cache_filter.py
+++ b/tests/test_ffi_cache_filter.py
@@ -1,0 +1,39 @@
+import io
+import pickle
+
+import cffi
+import cffi.model
+import pytest
+
+import pyvex.native as native
+
+
+def _restricted_loads(blob):
+    return native._RestrictedUnpickler(io.BytesIO(blob)).load()
+
+
+def test_rejects_arbitrary_callable_gadget():
+    class Evil:
+        def __reduce__(self):
+            return (print, ("pwned",))
+    # A bare pickle.loads would invoke the callable; the restricted unpickler refuses.
+    with pytest.raises(pickle.UnpicklingError):
+        _restricted_loads(pickle.dumps(Evil()))
+
+
+def test_rejects_cffi_model_helper_function():
+    class Evil2:
+        def __reduce__(self):
+            return (cffi.model.global_cache, ())
+    with pytest.raises(pickle.UnpicklingError):
+        _restricted_loads(pickle.dumps(Evil2()))
+
+
+def test_allows_legitimate_cffi_model_cache():
+    ffi = cffi.FFI()
+    ffi.cdef("typedef struct { int x; int y; } P; int add(int, int); enum C { A, B };")
+    legit = {"_declarations": ffi._parser._declarations,
+             "_int_constants": ffi._parser._int_constants}
+    loaded = _restricted_loads(pickle.dumps(legit))
+    assert set(loaded) == {"_declarations", "_int_constants"}
+    assert loaded["_declarations"].keys() == legit["_declarations"].keys()

--- a/tests/test_ffi_cache_filter.py
+++ b/tests/test_ffi_cache_filter.py
@@ -16,6 +16,7 @@ def test_rejects_arbitrary_callable_gadget():
     class Evil:
         def __reduce__(self):
             return (print, ("pwned",))
+
     # A bare pickle.loads would invoke the callable; the restricted unpickler refuses.
     with pytest.raises(pickle.UnpicklingError):
         _restricted_loads(pickle.dumps(Evil()))
@@ -25,6 +26,7 @@ def test_rejects_cffi_model_helper_function():
     class Evil2:
         def __reduce__(self):
             return (cffi.model.global_cache, ())
+
     with pytest.raises(pickle.UnpicklingError):
         _restricted_loads(pickle.dumps(Evil2()))
 
@@ -32,8 +34,7 @@ def test_rejects_cffi_model_helper_function():
 def test_allows_legitimate_cffi_model_cache():
     ffi = cffi.FFI()
     ffi.cdef("typedef struct { int x; int y; } P; int add(int, int); enum C { A, B };")
-    legit = {"_declarations": ffi._parser._declarations,
-             "_int_constants": ffi._parser._int_constants}
+    legit = {"_declarations": ffi._parser._declarations, "_int_constants": ffi._parser._int_constants}
     loaded = _restricted_loads(pickle.dumps(legit))
     assert set(loaded) == {"_declarations", "_int_constants"}
     assert loaded["_declarations"].keys() == legit["_declarations"].keys()


### PR DESCRIPTION
## Problem
`import pyvex` (and therefore `import angr`) reads a cffi FFI parser cache from a world-predictable path in the shared temp directory and deserializes it with a bare `pickle.loads` (`pyvex/native.py`):

    cache_location = os.path.join(tempfile.gettempdir(), f"pyvex_ffi_parser_cache.{username}.{hash_}")
    if os.path.isfile(cache_location):
        with open(cache_location, "rb") as f:
            cache = pickle.loads(f.read())

The path is `gettempdir()/pyvex_ffi_parser_cache.<getuser()>.<md5(ffi_str)>`: the username is public and the hash is a fixed per-version constant. On a shared multi-user host a co-tenant can plant a poisoned cache file, and because `pickle.loads` executes arbitrary reduce callables, the next `import pyvex` runs attacker code as the victim (CWE-502 / CWE-377).

This is local, defense-in-depth hardening rather than a remote vulnerability, and it is the same deserialization-cache class recently hardened in keras and pdfminer.six.

## Fix
The cache legitimately contains only `cffi.model` type classes, so a bare unpickle is unnecessary. This replaces `pickle.loads` with a `RestrictedUnpickler` whose `find_class` allows only `cffi.model` classes and rejects everything else, so a poisoned cache raises `UnpicklingError` instead of executing. No behaviour change on a legitimate cache.

## Test
`tests/test_ffi_cache_filter.py`: an arbitrary-callable gadget is rejected; a `cffi.model` helper *function* is also rejected (the allow-list is class-only, so it cannot be used as a gadget); and a legitimate `cffi.model` cache still loads. The full test suite passes (67).
