### PR TITLE
Lifting: Tell libVEX how much of the lift buffer it may read.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,8 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E env
         ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/make_ffi.py ${CMAKE_SOURCE_DIR}/vex/pub
     DEPENDS ${CMAKE_SOURCE_DIR}/vex/pub/libvex_guest_offsets.h
+            ${CMAKE_SOURCE_DIR}/vex/pub/libvex.h
+            ${CMAKE_SOURCE_DIR}/pyvex_c/pyvex.h
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMENT "Generating pyvex/vex_ffi.py using make_ffi.py"
 )

--- a/pyvex/lifting/libvex.py
+++ b/pyvex/lifting/libvex.py
@@ -31,6 +31,8 @@ LIBVEX_SUPPORTED_ARCHES = {
 
 VEX_MAX_INSTRUCTIONS = 99
 VEX_MAX_BYTES = 5000
+# libVEX stores the buffer size in an Int.
+VEX_MAX_BUFFER_SIZE = 0x7FFFFFFF
 
 
 class VexRegisterUpdates:
@@ -80,19 +82,29 @@ class LibVEXLifter(Lifter):
             if strict_block_end is None:
                 strict_block_end = True
 
+            # The s390x EXRL target is read straight out of the buffer, and it
+            # can sit well past max_bytes, so libVEX needs to know how much of
+            # the buffer is there. A bare pointer carries no size; leave it
+            # unstated then, and libVEX reads no further than max_bytes.
+            if ffi.typeof(self.data).kind == "array":
+                buffer_size = min(max(ffi.sizeof(self.data) - self.bytes_offset, 0), VEX_MAX_BUFFER_SIZE)
+            else:
+                buffer_size = 0
+
             if self.cross_insn_opt:
                 px_control = VexRegisterUpdates.VexRegUpdUnwindregsAtMemAccess
             else:
                 px_control = VexRegisterUpdates.VexRegUpdLdAllregsAtEachInsn
 
             vex_archinfo["hwcache_info"]["caches"] = ffi.NULL
-            lift_r = pvc.vex_lift(
+            lift_r = pvc.vex_lift_with_buffer_size(
                 vex_arch,
                 vex_archinfo,
                 self.data + self.bytes_offset,
                 self.irsb.addr,
                 max_inst,
                 max_bytes,
+                buffer_size,
                 self.opt_level,
                 self.traceflags,
                 self.allow_arch_optimizations,

--- a/pyvex/lifting/lift_function.py
+++ b/pyvex/lifting/lift_function.py
@@ -112,10 +112,12 @@ def lift(
                     # near) it. Lift from a copy padded with 8 NUL bytes so
                     # such reads are deterministic instead of heap garbage;
                     # keep the zero-copy path when there is enough slack.
+                    # The result is a sized char[]; libvex.py passes that size
+                    # on for decoders that read outside the block.
                     if isinstance(py_data, (bytearray, memoryview)) and bytes_offset + max_bytes + 8 <= len(py_data):
-                        u_data = ffi.from_buffer(ffi.BVoidP, py_data)
+                        u_data = ffi.from_buffer(py_data)
                     else:
-                        u_data = ffi.from_buffer(ffi.BVoidP, bytes(py_data) + b"\0" * 8)
+                        u_data = ffi.from_buffer(bytes(py_data) + b"\0" * 8)
                 else:
                     u_data = c_data
                 skip = 0

--- a/pyvex_c/pyvex.c
+++ b/pyvex_c/pyvex.c
@@ -329,6 +329,28 @@ VEXLiftResult *vex_lift(
 		int const_prop,
 		VexRegisterUpdates px_control,
 		unsigned int lookback) {
+	return vex_lift_with_buffer_size(guest, archinfo, insn_start, insn_addr, max_insns, max_bytes,
+			0 /* buffer_size */, opt_level, traceflags, allow_arch_optimizations, strict_block_end,
+			collect_data_refs, load_from_ro_regions, const_prop, px_control, lookback);
+}
+
+VEXLiftResult *vex_lift_with_buffer_size(
+		VexArch guest,
+		VexArchInfo archinfo,
+		unsigned char *insn_start,
+		unsigned long long insn_addr,
+		unsigned int max_insns,
+		unsigned int max_bytes,
+		unsigned int buffer_size,
+		int opt_level,
+		int traceflags,
+		int allow_arch_optimizations,
+		int strict_block_end,
+		int collect_data_refs,
+		int load_from_ro_regions,
+		int const_prop,
+		VexRegisterUpdates px_control,
+		unsigned int lookback) {
 	VexRegisterUpdates pxControl = px_control;
 
 	vex_prepare_vai(guest, &archinfo);
@@ -346,6 +368,7 @@ VEXLiftResult *vex_lift(
 	vta.traceflags          = traceflags;
 
 	vc.guest_max_bytes     = max_bytes;
+	vc.guest_bytes_size    = buffer_size;
 	vc.guest_max_insns     = max_insns;
 	vc.iropt_level         = opt_level;
 	vc.lookback_amount     = lookback;

--- a/pyvex_c/pyvex.def
+++ b/pyvex_c/pyvex.def
@@ -48,6 +48,7 @@ EXPORTS
   typeOfPrimop
   clear_log
   vex_lift
+  vex_lift_with_buffer_size
   vex_init
   register_readonly_region
   deregister_all_readonly_regions

--- a/pyvex_c/pyvex.h
+++ b/pyvex_c/pyvex.h
@@ -88,6 +88,28 @@ VEXLiftResult *vex_lift(
 		VexRegisterUpdates px_control,
 		unsigned int lookback_amount);
 
+// As vex_lift, but the caller also states how many bytes are readable at
+// insn_start. A decoder that looks outside the block it is lifting -- the
+// s390x EXRL target is read out of the buffer -- stays inside that. Zero
+// means unstated, in which case no more than max_bytes is read.
+VEXLiftResult *vex_lift_with_buffer_size(
+		VexArch guest,
+		VexArchInfo archinfo,
+		unsigned char *insn_start,
+		unsigned long long insn_addr,
+		unsigned int max_insns,
+		unsigned int max_bytes,
+		unsigned int buffer_size,
+		int opt_level,
+		int traceflags,
+		int allow_arch_optimizations,
+		int strict_block_end,
+		int collect_data_refs,
+		int load_from_ro_regions,
+		int const_prop,
+		VexRegisterUpdates px_control,
+		unsigned int lookback_amount);
+
 Bool register_readonly_region(ULong start, ULong size, unsigned char* content);
 void deregister_all_readonly_regions();
 Bool register_initial_register_value(UInt offset, UInt size, ULong value);

--- a/tests/test_s390x_exrl.py
+++ b/tests/test_s390x_exrl.py
@@ -21,5 +21,119 @@ def test_s390x_exrl():
     assert irsb.jumpkind == "Ijk_Ret"
 
 
+def test_s390x_exrl_target_before_buffer():
+    """The EXRL displacement is signed. Reading it as unsigned aimed the target
+    about 8GB past the buffer, and put that address in the emitted lookup too.
+    """
+    arch = pyvex.ARCH_S390X
+    irsb = pyvex.lift(
+        b"\xc6\x10\xff\xff\xff\x00"  # exrl %r1,0x400200
+        b"\x07\xfe",  # br %r14
+        0x400400,
+        arch,
+    )
+    irsb_str = str(irsb)
+
+    # The target is 0x200 bytes back, so it is not in the buffer and cannot be
+    # prefetched; the run-time lookup is emitted, and it reads the right place.
+    assert "LDbe:I64(0x0000000000400200)" in irsb_str
+    assert "s390x_dirtyhelper_EX" in irsb_str
+    assert irsb.size == 6
+    assert irsb.jumpkind == "Ijk_InvalICache"
+
+
+def test_s390x_exrl_target_past_buffer():
+    """Nothing constrains the displacement, so a bogus EXRL points anywhere
+    within 4GB of the buffer. Nothing outside it is read; the run-time lookup
+    resolves the target instead.
+    """
+    arch = pyvex.ARCH_S390X
+    irsb = pyvex.lift(
+        b"\xc6\x10\x00\x00\x10\x00"  # exrl %r1,0x402400
+        b"\x07\xfe",  # br %r14
+        0x400400,
+        arch,
+    )
+    irsb_str = str(irsb)
+
+    assert "LDbe:I64(0x0000000000402400)" in irsb_str
+    assert "s390x_dirtyhelper_EX" in irsb_str
+    assert irsb.size == 6
+    assert irsb.jumpkind == "Ijk_InvalICache"
+
+
+def test_s390x_exrl_target_past_max_bytes():
+    """An EXRL target may sit outside the lift window and still be inside the
+    caller's buffer, which is how angr lifts: it hands over a whole segment and
+    caps the block at max_bytes. The target is readable, so it is still used.
+    """
+    arch = pyvex.ARCH_S390X
+    block = (
+        b"\xc6\x10\x00\x00\x00\x64"  # exrl %r1,0x4004c8
+        b"\x07\xfe"  # br %r14
+    )
+    target = b"\xd7\x00\x20\x00\x30\x00"  # xc 0(0,%r2),0(%r3)
+    buf = bytearray(block + b"\x00" * (0xC8 - len(block)) + target)
+
+    for data in (bytes(buf), pyvex.ffi.from_buffer(buf)):
+        irsb = pyvex.lift(data, 0x400400, arch, max_bytes=len(block))
+        assert "0xd700200030000000" in str(irsb)
+        assert irsb.jumpkind == "Ijk_Ret"
+
+    # Drop the last byte of the target and it no longer fits in the buffer.
+    irsb = pyvex.lift(pyvex.ffi.from_buffer(buf[:-1]), 0x400400, arch, max_bytes=len(block))
+    assert "0xd700200030000000" not in str(irsb)
+    assert irsb.jumpkind == "Ijk_InvalICache"
+
+    # A bare pointer has no extent to state, so max_bytes is all that is read.
+    sized = pyvex.ffi.from_buffer(buf)
+    irsb = pyvex.lift(pyvex.ffi.cast("unsigned char *", sized), 0x400400, arch, max_bytes=len(block))
+    assert "0xd700200030000000" not in str(irsb)
+    assert irsb.jumpkind == "Ijk_InvalICache"
+
+
+def test_s390x_exrl_inside_a_larger_buffer():
+    """The whole segment angr hands over starts before the block, and the EXRL
+    need not be the block's first instruction, so the target is displaced from
+    the EXRL rather than from either start.
+    """
+    arch = pyvex.ARCH_S390X
+    block = (
+        b"\xa7\x5b\xff\xff"  # aghi %r5,-1
+        b"\xc6\x10\x00\x00\x00\x62"  # exrl %r1,0x4004c8
+        b"\x07\xfe"  # br %r14
+    )
+    target = b"\xd7\x00\x20\x00\x30\x00"  # xc 0(0,%r2),0(%r3)
+    prefix = b"\x07\xfe" * 8  # code before the block, never decoded
+    buf = bytearray(prefix + block + b"\x00" * (0xC8 - len(block)) + target)
+
+    irsb = pyvex.lift(pyvex.ffi.from_buffer(buf), 0x400400, arch, max_bytes=len(block), bytes_offset=len(prefix))
+    assert "0xd700200030000000" in str(irsb)
+    assert irsb.jumpkind == "Ijk_Ret"
+
+
+def test_s390x_exrl_truncated():
+    """A block whose last instruction is a truncated EXRL. CFGFast lifts at
+    addresses it finds by scanning, so it hands the lifter such a block
+    routinely.
+    """
+    arch = pyvex.ARCH_S390X
+    irsb = pyvex.lift(
+        b"\xa7\x5b\xff\xff"  # aghi %r5,-1
+        b"\xc6\x50\xff",  # first three bytes of a six-byte exrl
+        0x1000,
+        arch,
+    )
+
+    # The exrl does not fit in the block, so only the aghi is lifted.
+    assert irsb.size == 4
+    assert irsb.jumpkind == "Ijk_Boring"
+
+
 if __name__ == "__main__":
     test_s390x_exrl()
+    test_s390x_exrl_target_before_buffer()
+    test_s390x_exrl_target_past_buffer()
+    test_s390x_exrl_target_past_max_bytes()
+    test_s390x_exrl_inside_a_larger_buffer()
+    test_s390x_exrl_truncated()

--- a/tests/test_s390x_exrl.py
+++ b/tests/test_s390x_exrl.py
@@ -1,4 +1,30 @@
+import os
+import unittest
+
 import pyvex
+
+# angr/binaries is checked out beside the repository under test in the
+# ecosystem CI job. The standalone platform jobs check out pyvex alone, so the
+# real-binary test below skips there.
+BINARIES = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
+ACME_CLIENT = os.path.join(BINARIES, "s390x", "exrl", "acme-client")
+
+# angr maps that PIE at 0x400000 and CFGFast scans the executable segment for
+# code, which lands it on 0x40723a. Nothing executes there: the entry stub ends
+# at 0x407233 and branches to 0x407240, and 0x40723a is two bytes into the word
+# at 0x407238 that the stub loads to find _DYNAMIC. Its low half plus the
+# padding after it read as exrl %r6 with a target 235,802,126 bytes ahead.
+# tests/s390x/exrl/README.md in angr/binaries has the rest.
+LOAD_BASE = 0x400000
+ENTRY_OFFSET = 0x7210
+EXRL_OFFSET = 0x723A
+
+
+def read_acme_client():
+    if not os.path.isdir(BINARIES):
+        raise unittest.SkipTest(f"angr/binaries is not checked out beside pyvex: {BINARIES} is missing")
+    with open(ACME_CLIENT, "rb") as fp:
+        return fp.read()
 
 
 def test_s390x_exrl():
@@ -130,6 +156,39 @@ def test_s390x_exrl_truncated():
     assert irsb.jumpkind == "Ijk_Boring"
 
 
+def test_s390x_exrl_real_binary():
+    """A compiler-produced object that this used to kill the process on:
+    acme-client 1.3.5 for s390x, out of Alpine v3.23. CFGFast's scan reaches a
+    data word between two functions, the six bytes there decode as an EXRL
+    aiming 235,802,126 bytes ahead, and libVEX fetched that out of the
+    translation buffer without a bounds check -- around 225 MiB past the end of
+    the 73,920-byte executable segment cle hands over.
+    """
+    image = read_acme_client()
+    arch = pyvex.ARCH_S390X
+
+    # The entry stub, lifted out of the file. Nothing in it reads outside the
+    # buffer, so it says the fixture is being read and lifted correctly. Its
+    # last instruction is the branch to 0x407240, which is why nothing ever
+    # runs the bytes the scan trips on.
+    irsb = pyvex.lift(image, LOAD_BASE + ENTRY_OFFSET, arch, bytes_offset=ENTRY_OFFSET)
+    assert irsb.size == 36
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert "PUT(ia) = 0x0000000000407240; Ijk_Boring" in str(irsb)
+
+    # And the address the scan reaches, both as the whole file and as the six
+    # bytes a block cut at max_bytes leaves. The target is far outside the
+    # buffer either way, so it is not prefetched and the run-time lookup is
+    # emitted instead.
+    for data, offset in ((image, EXRL_OFFSET), (image[EXRL_OFFSET : EXRL_OFFSET + 6], 0)):
+        irsb = pyvex.lift(data, LOAD_BASE + EXRL_OFFSET, arch, bytes_offset=offset)
+        irsb_str = str(irsb)
+        assert "LDbe:I64(0x000000000e4e8048)" in irsb_str
+        assert "s390x_dirtyhelper_EX" in irsb_str
+        assert irsb.size == 6
+        assert irsb.jumpkind == "Ijk_InvalICache"
+
+
 if __name__ == "__main__":
     test_s390x_exrl()
     test_s390x_exrl_target_before_buffer()
@@ -137,3 +196,4 @@ if __name__ == "__main__":
     test_s390x_exrl_target_past_max_bytes()
     test_s390x_exrl_inside_a_larger_buffer()
     test_s390x_exrl_truncated()
+    test_s390x_exrl_real_binary()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Lifting s390x takes the interpreter down, with no exception to catch. Six
well-formed bytes are enough — `c660ffffffff` is `exrl %r6,.-2`, the backward
form compilers emit for literal-pool-relative `MVC` and `CLC`:

```
$ pyvex.lift(bytes.fromhex("c660ffffffff"), 0x1000, archinfo.ArchS390X())
  [killed by SIGSEGV]
$ pyvex.lift(bytes.fromhex("c66000000003"), 0x1000, archinfo.ArchS390X())
  NEXT: PUT(ia) = 0x0000000000001000; Ijk_InvalICache
```

The sign of the displacement is the whole difference. `a75bffffc650ff` — an
`aghi` followed by a truncated `exrl`, which is what a scanning CFG produces —
dies the same way.

### Root cause

libVEX's s390x front end reads the `EXRL` execute target out of the buffer it
was handed, at a displacement nothing bounds; the vex branch this bumps to
bounds that read.

The half this repository owns is that pyvex never told libVEX how large that
buffer is. `pvc.vex_lift` passes `max_bytes`, which is the size of the block to
translate, not the size of the readable region: angr hands over a whole segment
and caps the block at `VEX_IRSB_MAX_SIZE`, 400 bytes, and real `EXRL` targets
sit past that cap, so bounding the prefetch by `max_bytes` alone would drop
legitimate targets. pyvex did know the extent and threw it away:
`lift_function.py` cast the cffi buffer through `ffi.BVoidP`, and a `void *`
carries no size.

```
>>> ffi.sizeof(ffi.from_buffer(ffi.BVoidP, bytearray(64)))   # <ctype 'void *'>
8
>>> ffi.sizeof(ffi.from_buffer(bytearray(64)))               # <ctype 'char[]'>
64
```

### Fix

Keep the sized `char[]` and state its extent. `libvex.py` computes
`ffi.sizeof(self.data) - self.bytes_offset` when the object is an array, zero
when it is a bare pointer, and passes it to a new `vex_lift_with_buffer_size`,
which sets `vc.guest_bytes_size`. `vex_lift` keeps its signature and forwards
zero — unstated — so angr's native consumers build and run unchanged. The
submodule bump points at the vex branch that consumes the field.

### Testing

`tests/test_s390x_exrl.py` covers a target before the buffer, one past it, one
past `max_bytes` but still inside the buffer, one reached through a non-zero
`bytes_offset`, and a truncated encoding. All six pass on this head, five runs
of five. Without the fix two are killed by SIGSEGV and two fail their
assertions. One of those two, `test_s390x_exrl_target_past_buffer`, reads
uninitialised heap 8 KiB past the buffer, so what it finds is not guaranteed:
unfixed it failed 236 of 240 fresh interpreters and passed four.

A seventh test lifts real compiler output instead of a byte string:
`tests/s390x/exrl/acme-client`, the Alpine v3.23 s390x build of acme-client
1.3.5 that went into angr/binaries as pull request 222, at `0x40723a`. That is where `CFGFast`'s scan of the
executable segment lands -- two bytes into the word the entry stub loads to find
`_DYNAMIC` -- and the six bytes there decode as `exrl %r6` aiming 235,802,126
bytes ahead, about 225 MiB past the end of the 73,920-byte segment cle hands
over. It is killed by SIGSEGV in forty fresh interpreters out of forty without
the fix, and `CFGFast` over the whole file is killed on pyvex master three
runs out of three, where this head recovers 435 functions. Sites already in
`tests/s390x` crash the same way when lifted at a fixed offset -- `ld64.so.1`
at `0x1304`, say -- but a scan starts a block at none of the seventy such sites
in the repository, so the new object is the only one where the address a test
pins is one an analysis really reaches. angr/binaries is a sibling only in the
`ecosystem` job; the standalone platform jobs check out pyvex alone, and the
test skips there naming the directory it wanted.

Needs angr/vex#89, which the submodule bump here points at.

Fixes #561. Validation: https://github.com/angr/pyvex/pull/564#issuecomment-5257392181

Merge order: angr/vex#89 goes in before this one. This head's `vex` submodule is `88aa12d`, which is that pull request's head and one commit ahead of `vex` master, so merging this half on its own leaves pyvex master's submodule pointing at a commit that is on no vex branch. The fixture half has already landed -- binaries master carries `tests/s390x/exrl/acme-client` since 2026-08-31 -- so the seventh test loads it from there and no reference to that repository is needed here. `angr/vex` is not in the CI repository list, so the `sync:` line below is a note to the reader rather than an instruction to CI.

sync: angr/vex#89

session: sharpen