### PR TITLE
Lifting: Decode RISC-V store-conditional and float comparisons again

### DIFF
--- a/tests/test_riscv64_ir_types.py
+++ b/tests/test_riscv64_ir_types.py
@@ -1,0 +1,34 @@
+import pyvex
+
+
+def test_riscv64_sc():
+    # sc.{w,d} builds an IRStmt_LLSC whose result the IR contract fixes at Ity_I1. Giving the temp a
+    # wider type makes the statement fail the IR sanity check, and libVEX then reports the whole
+    # block as NoDecode -- so every store-conditional in a RISC-V binary became undecodable bytes.
+    for encoding, name in ((b"\xaf\x36\xb9\x18", "sc.d a3, a1, (s2)"), (b"\xaf\x26\xb9\x18", "sc.w a3, a1, (s2)")):
+        irsb = pyvex.lift(encoding + b"\x82\x80", 0x1000, pyvex.ARCH_RISCV64_LE)
+        assert irsb.jumpkind != "Ijk_NoDecode", name
+        assert irsb.instruction_addresses[0] == 0x1000
+        assert irsb.instruction_addresses[1] == 0x1004
+
+
+def test_riscv64_float_comparisons():
+    # feq and flt compare into a temp the same way fle does. fle wraps the Ity_I1 comparison in
+    # Iop_1Uto32 to match its Ity_I32 temp; feq and flt did not, and failed the sanity check.
+    encodings = {
+        "feq.s": b"\x53\x25\xb5\xa0",
+        "flt.s": b"\x53\x15\xb5\xa0",
+        "fle.s": b"\x53\x05\xb5\xa0",
+        "feq.d": b"\x53\x25\xb5\xa2",
+        "flt.d": b"\x53\x15\xb5\xa2",
+        "fle.d": b"\x53\x05\xb5\xa2",
+    }
+    for name, encoding in encodings.items():
+        irsb = pyvex.lift(encoding + b"\x82\x80", 0x1000, pyvex.ARCH_RISCV64_LE)
+        assert irsb.jumpkind != "Ijk_NoDecode", name
+        assert irsb.instruction_addresses[1] == 0x1004, name
+
+
+if __name__ == "__main__":
+    test_riscv64_sc()
+    test_riscv64_float_comparisons()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`sc.w`, `sc.d`, `feq.s`, `flt.s`, `feq.d` and `flt.d` have not decoded since angr/vex's `7576d04`. `pyvex.lift(bytes.fromhex("af36b918"), 0x1000, pyvex.ARCH_RISCV64_LE)` — an `sc.d a3, a1, (s2)` — returns `Ijk_NoDecode` with size 0.

The damage is not confined to the offending instruction. Because libVEX rejects the whole block, every instruction that decoded before it is discarded too: lifting from `0x41ac88` in a RISC-V64 object returns size 0 although its first nineteen instructions decode, and `flt.d` is instruction twenty. `CFGFast` then restarts its scan two bytes in and everything after is off by two.

### Root cause

`7576d04` widened the `Ity_I1` temporaries behind these encodings, so each one now fails libVEX's IR sanity check with `Ist.LLSC(SC).result: not :: Ity_I1`.

### Fix

`IRStmt_LLSC` fixes its result type at `Ity_I1` by the IR contract in `pub/libvex_ir.h`, so the store-conditionals are spelled the way `guest_arm64_toIR.c` spells them. `feq` and `flt` wrap their comparisons in `Iop_1Uto32`, as the `fle` sharing their temp already did.

### Testing

`tests/test_riscv64_ir_types.py` covers all six forms plus the two that were never broken, and fails on the first `Ijk_NoDecode` assertion with the submodule pointed back at `875f7c9`. Needs angr/vex#90, which the submodule bump here already points at. Before/after lifter output is in the comment below.

Fixes #516, whose diagnosis names `flt` only.

Validation: https://github.com/angr/pyvex/pull/566#issuecomment-5287246143

Merge order: angr/vex#90 first. This head's `vex` submodule is `3ce6fb2`, which is that pull request's head and one commit ahead of `vex` master, so merging this half on its own leaves pyvex master's submodule pointing at a commit that is on no vex branch. `angr/vex` is not in the CI repository list, so the `sync:` line below is a note to the reader rather than an instruction to CI.

sync: angr/vex#90

session: sharpen