### PR TITLE
Do not fail the import when the FFI parser cache cannot be written

### DIFF
--- a/pyvex/native.py
+++ b/pyvex/native.py
@@ -30,16 +30,20 @@ def _parse_ffi_str():
         ffi._parser._int_constants = cache["_int_constants"]
     else:
         ffi.cdef(_ffi_str)
-        # cache the result
         cache = {
             "_declarations": ffi._parser._declarations,
             "_int_constants": ffi._parser._int_constants,
         }
-        # atomically write cache
-        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            temp_file.write(pickle.dumps(cache))
-            temp_file_name = temp_file.name
-        os.replace(temp_file_name, cache_location)
+        # Publishing the cache is best-effort: the declarations are already complete, and a
+        # process that cannot write the file loses nothing because whichever one wins the race
+        # writes the same bytes. Either way the temporary file goes away with the block.
+        try:
+            with tempfile.NamedTemporaryFile(delete_on_close=False) as temp_file:
+                temp_file.write(pickle.dumps(cache))
+                temp_file.close()
+                os.replace(temp_file.name, cache_location)
+        except OSError:
+            pass
 
 
 def _find_c_lib():

--- a/tests/test_ffi_parser_cache.py
+++ b/tests/test_ffi_parser_cache.py
@@ -1,0 +1,49 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+import cffi
+
+import pyvex.native
+
+
+def _parse_into_fresh_ffi():
+    """Parse the FFI string into a new FFI object and return the type names it declares."""
+    pyvex.native.ffi = cffi.FFI()
+    pyvex.native._parse_ffi_str()
+    return pyvex.native.ffi.list_types()
+
+
+class TestFFIParserCache(unittest.TestCase):
+    """The parser cache only saves startup time, so a process that cannot write it must
+    still come away with the declarations it needs."""
+
+    def setUp(self):
+        saved_ffi = pyvex.native.ffi
+        saved_tempdir = tempfile.tempdir
+        self.addCleanup(setattr, pyvex.native, "ffi", saved_ffi)
+        self.addCleanup(setattr, tempfile, "tempdir", saved_tempdir)
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+        tempfile.tempdir = self.tempdir
+
+    def test_parses_when_the_cache_cannot_be_written(self):
+        types = _parse_into_fresh_ffi()
+        self.assertIn("IRSB", types[0])
+
+        (cache_name,) = os.listdir(self.tempdir)
+        cache_location = os.path.join(self.tempdir, cache_name)
+
+        # Turn the cache into a directory so that replacing it fails on every platform.
+        # Windows fails the same replacement with a PermissionError whenever another
+        # process holds the cache file open for reading.
+        os.unlink(cache_location)
+        os.mkdir(cache_location)
+
+        self.assertEqual(_parse_into_fresh_ffi(), types)
+        self.assertEqual(os.listdir(self.tempdir), [cache_name])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Importing pyvex from several processes at once can fail on Windows. On a
`Test windows-2022` job of an unrelated cle pull request, every test in the
shard errored during collection:

```
ERROR collecting tests/test_aarch64_relocations.py
E   PermissionError: [WinError 5] Access is denied:
      '...\Temp\tmpnq9kav_i' -> '...\Temp\pyvex_ffi_parser_cache.runneradmin.c10af...'
ERROR collecting tests/test_address_translator.py
E   AttributeError: module 'pyvex' has no attribute 'vex_ffi'
```

The second error is the cascade from the first: the process that loses the
`os.replace` race leaves `pyvex` half-imported, so every later import in that
shard finds no `vex_ffi`. One such run ended in `52 errors in 5.77s`
([log](https://github.com/angr/cle/actions/runs/32585269138/job/97060571985)),
while the same attempt's `Test macos-15` passed -- so the failure reads as a
defect in the change under review, on a pull request that does not touch pyvex.

### Root cause

`_parse_ffi_str` publishes its cffi parser cache unguarded:

```python
with tempfile.NamedTemporaryFile(delete=False) as temp_file:
    temp_file.write(pickle.dumps(cache))
    temp_file_name = temp_file.name
os.replace(temp_file_name, cache_location)
```

`os.replace` is atomic on POSIX but refuses to overwrite a file another process
holds open on Windows, and `delete=False` means the failure also leaks the
temporary file. Both are visible on Linux by making the destination
unreplaceable -- the parse raises `IsADirectoryError` from that same line, and
the temp directory is left holding `tmpzjql4v9i` beside the cache.

The declarations are already complete by the time this runs: the failure is in
publishing a cache, not in parsing.

### Fix

Wrap the write and the replace in `try/except OSError` and use
`delete_on_close=False`, so the temporary file goes away with the block whether
or not the replacement succeeds. Whichever process wins the race writes the same
bytes, so a process that loses it loses nothing but the saved startup time. This
is not made a Windows special case, because a read-only or full temp directory
fails the same way everywhere.

The same forced failure then returns declarations identical to the uncached
parse, with no leftover temporary file.

### Testing

`tests/test_ffi_parser_cache.py` parses into a fresh `cffi.FFI` under a private
`tempfile.tempdir`, replaces the written cache with a directory, and asserts the
second parse returns the same type list and that the directory holds nothing
else. It fails on the merge base with `IsADirectoryError`.

The Windows failure itself is covered by the CI log linked above rather than
reproduced locally. #562 changes the read side of this function without
overlapping this.

Validation: https://github.com/angr/pyvex/pull/569#issuecomment-5381669054

session: sharpen
