### PR TITLE
Lifting: Keep a stale s390x execute target from suppressing later EXRL expansion

### DIFF
--- a/tests/test_s390x_ex_stale_target.py
+++ b/tests/test_s390x_ex_stale_target.py
@@ -1,0 +1,22 @@
+import pyvex
+
+# exrl %r1,0x400408; br %r14; xc 0(0,%r2),0(%r3); padding
+EXPANDABLE = b"\xc6\x10\x00\x00\x00\x04\x07\xfe\xd7\x00\x20\x00\x30\x00\x7d\xa7"
+
+# The same block with an execute target whose first byte is 0x00. libVEX
+# selects the arm of s390_irgen_EX that has no code information yet on that
+# byte, and caches the target in a global that outlives the lift.
+LEADING_ZERO_TARGET = b"\xc6\x10\x00\x00\x00\x04\x07\xfe\x00\x07\x20\x00\x30\x00\x7d\xa7"
+
+
+def expands_execute_target(data):
+    return "0xd700200030000000" in str(pyvex.lift(data, 0x400400, pyvex.ARCH_S390X))
+
+
+def test_s390x_ex_leading_zero_target_does_not_persist():
+    pyvex.lift(LEADING_ZERO_TARGET, 0x400400, pyvex.ARCH_S390X)
+    assert expands_execute_target(EXPANDABLE)
+
+
+if __name__ == "__main__":
+    test_s390x_ex_leading_zero_target_does_not_persist()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Lifting an s390x `EXRL` whose six execute-target bytes begin `0x00` silently degrades every later `EXRL` in the same process. With the vectors in `tests/test_s390x_ex_stale_target.py`, an expandable `EXRL` expands its execute target on a clean process, stops expanding after one such block is lifted, and lifts to an opaque invalidate-and-restart block from then on.

One block of misidentified code therefore corrupts the lift of every s390x binary analysed afterwards, and nothing reports it.

### Root cause

libVEX caches the execute target in a global. One arm of `s390_irgen_EX` — the arm selected when the target's first byte carries no code information yet — returns without clearing it, so the stale value outlives the lift.

### Fix

Clear the global on that arm too. The fix does not depend on the state the process starts in, since the global is cleared whichever way the arm is entered.

### Testing

`tests/test_s390x_ex_stale_target.py` asserts across two lifts, because the state being tested is a libVEX global rather than anything reachable from one IRSB. It fails against the baseline submodule. With the file present, `tests/test_s390x_exrl.py::test_s390x_exrl` also fails on the baseline, because the stale global survives into the following test file. Needs angr/vex#94, which the submodule bump here already points at. The sequence is in the comment below.

The submodule bump conflicts textually with the ones in #564 and #570, so whichever lands first, the others rebase.

Validation: https://github.com/angr/pyvex/pull/571#issuecomment-5384416632

Merge order: angr/vex#94 first. This head's `vex` submodule is `f7b8fcc`, which is that pull request's head and one commit ahead of `vex` master, so merging this half on its own leaves pyvex master's submodule pointing at a commit that is on no vex branch. `angr/vex` is not in the CI repository list, so the `sync:` line below is a note to the reader rather than an instruction to CI.

sync: angr/vex#94

session: sharpen