### PR TITLE
Do not lose a decode error to its own handler

### DIFF
--- a/pyvex/lifting/util/lifter_helper.py
+++ b/pyvex/lifting/util/lifter_helper.py
@@ -80,11 +80,12 @@ class GymratLifter(Lifter):
         log.debug("Address: %#08x" % addr)
 
     def decode(self):
+        addr = self.irsb.addr
+        bytepos = 0
         try:
             self.create_bitstrm()
             count = 0
             disas = []
-            addr = self.irsb.addr
             log.debug("Starting block at address: " + hex(addr))
             bytepos = self.bitstrm.bytepos
 

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -31,6 +31,25 @@ class TestLift(unittest.TestCase):
         assert block.instructions == 1
         assert block.jumpkind == JumpKind.NoDecode
 
+    def test_decode_error_reaches_the_caller_as_itself(self):
+        """This tests that a failure before the first instruction is decoded reaches
+        the caller as itself, rather than as an UnboundLocalError raised by the
+        handler that reports it.
+        """
+
+        class CreateBitstrmError(Exception):
+            pass
+
+        class BrokenLifter(GymratLifter):
+            instrs = []
+
+            def create_bitstrm(self):
+                raise CreateBitstrmError("no stream")
+
+        lifter = BrokenLifter(pyvex.ARCH_AMD64, 0)
+        with self.assertRaises(CreateBitstrmError):
+            lifter.lift(b"\x90")
+
     def test_skipstmts_toomanyexits(self):
         # https://github.com/angr/pyvex/issues/153
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Any failure inside `GymratLifter.create_bitstrm()` reaches the caller as an
`UnboundLocalError` raised by the handler that was supposed to report it. A
lifter whose `create_bitstrm` raises `CreateBitstrmError("no stream")`, lifting
at address `0x0`:

```
  File "pyvex/lifting/util/lifter_helper.py", line 103, in decode
    log.exception(f"Error decoding block at offset {bytepos:#x} (address {addr:#x}):")
                                                    ^^^^^^^
UnboundLocalError: cannot access local variable 'bytepos' where it is not associated with a value
```

The real exception survives only as chained context, so every distinct failure
at that point -- a missing stream, a short buffer, an architecture the lifter
cannot set up -- surfaces to the caller as the same `UnboundLocalError` with the
same message.

### Root cause

`decode()` reports the failing offset and address from names that are bound
inside the `try` block the handler guards:

```python
def decode(self):
    try:
        self.create_bitstrm()
        count = 0
        disas = []
        addr = self.irsb.addr
        ...
        bytepos = self.bitstrm.bytepos
```

`create_bitstrm()` is the first statement in the block, so anything raised there
leaves both `bytepos` and `addr` unbound, and the `except` clause's own
`log.exception` f-string is what fails.

### Fix

Bind `addr = self.irsb.addr` and `bytepos = 0` before the `try`. `addr` is a
property of the IRSB the lifter was constructed with and does not depend on the
stream; `0` is the offset the block was about to start at. The handler then logs
`Error decoding block at offset 0x0 (address 0x0):` and re-raises
`CreateBitstrmError: no stream` unchanged.

### Testing

`test_decode_error_reaches_the_caller_as_itself` in `tests/test_lift.py`
subclasses `GymratLifter` with a `create_bitstrm` that raises, and asserts that
exception type reaches the caller. It fails on the merge base with
`UnboundLocalError`.

Validation: https://github.com/angr/pyvex/pull/573#issuecomment-5390323156

session: sharpen
