### PR TITLE
Support MIPSN32 in the lifter

### DIFF
--- a/pyvex/__init__.py
+++ b/pyvex/__init__.py
@@ -17,6 +17,8 @@ from .arches import (
     ARCH_MIPS32_LE,
     ARCH_MIPS64_BE,
     ARCH_MIPS64_LE,
+    ARCH_MIPSN32_BE,
+    ARCH_MIPSN32_LE,
     ARCH_PPC32,
     ARCH_PPC64_BE,
     ARCH_PPC64_LE,
@@ -88,5 +90,7 @@ __all__ = [
     "ARCH_MIPS32_LE",
     "ARCH_MIPS64_BE",
     "ARCH_MIPS64_LE",
+    "ARCH_MIPSN32_BE",
+    "ARCH_MIPSN32_LE",
     "ARCH_RISCV64_LE",
 ]

--- a/pyvex/arches.py
+++ b/pyvex/arches.py
@@ -27,6 +27,8 @@ class PyvexArch:
             "S390X": "VexArchS390X",
             "MIPS32": "VexArchMIPS32",
             "MIPS64": "VexArchMIPS64",
+            # n32/O64: a 64-bit instruction stream with 32-bit pointers.
+            "MIPSN32": "VexArchMIPS64",
             "RISCV64": "VexArchRISCV64",
         }[name]
         self.ip_offset = guest_offsets[
@@ -42,6 +44,7 @@ class PyvexArch:
                     "S390X": "ia",
                     "MIPS32": "pc",
                     "MIPS64": "pc",
+                    "MIPSN32": "pc",
                     "RISCV64": "pc",
                 }[name],
             )
@@ -91,4 +94,6 @@ ARCH_MIPS32_BE = PyvexArch("MIPS32", 32, "Iend_BE")
 ARCH_MIPS32_LE = PyvexArch("MIPS32", 32, "Iend_LE")
 ARCH_MIPS64_BE = PyvexArch("MIPS64", 64, "Iend_BE")
 ARCH_MIPS64_LE = PyvexArch("MIPS64", 64, "Iend_LE")
+ARCH_MIPSN32_BE = PyvexArch("MIPSN32", 32, "Iend_BE")
+ARCH_MIPSN32_LE = PyvexArch("MIPSN32", 32, "Iend_LE")
 ARCH_RISCV64_LE = PyvexArch("RISCV64", 64, "Iend_LE", instruction_endness="Iend_LE")

--- a/pyvex/arches.py
+++ b/pyvex/arches.py
@@ -27,7 +27,6 @@ class PyvexArch:
             "S390X": "VexArchS390X",
             "MIPS32": "VexArchMIPS32",
             "MIPS64": "VexArchMIPS64",
-            # n32/O64: a 64-bit instruction stream with 32-bit pointers.
             "MIPSN32": "VexArchMIPS64",
             "RISCV64": "VexArchRISCV64",
         }[name]

--- a/pyvex/lifting/libvex.py
+++ b/pyvex/lifting/libvex.py
@@ -17,6 +17,9 @@ LIBVEX_SUPPORTED_ARCHES = {
     "AMD64",
     "MIPS32",
     "MIPS64",
+    # n32 and O64: a 64-bit MIPS instruction stream with 32-bit pointers, so the guest is
+    # VexArchMIPS64 while the architecture's word size is 32.
+    "MIPSN32",
     "ARM",
     "ARMEL",
     "ARMHF",

--- a/pyvex/lifting/libvex.py
+++ b/pyvex/lifting/libvex.py
@@ -17,8 +17,6 @@ LIBVEX_SUPPORTED_ARCHES = {
     "AMD64",
     "MIPS32",
     "MIPS64",
-    # n32 and O64: a 64-bit MIPS instruction stream with 32-bit pointers, so the guest is
-    # VexArchMIPS64 while the architecture's word size is 32.
     "MIPSN32",
     "ARM",
     "ARMEL",

--- a/tests/test_mipsn32.py
+++ b/tests/test_mipsn32.py
@@ -1,0 +1,36 @@
+import pyvex
+
+
+def test_mipsn32_uses_the_64_bit_guest():
+    """
+    n32 and O64 hold a 64-bit MIPS instruction stream in an ELFCLASS32 container, so the guest
+    is VexArchMIPS64 while a pointer is 32 bits wide. `sd` -- the 64-bit store a non-leaf
+    prologue uses to spill $gp -- is where the 32-bit guest goes wrong: it lifts the same word
+    as a 4-byte store instead of refusing it.
+
+      10000110: 27bdffe0 ; addiu $sp, $sp, -0x20
+      10000114: ffbc0008 ; sd    $gp, 8($sp)
+      10000118: 3c1c0002 ; lui   $gp, 2
+    """
+    data = b"\x27\xbd\xff\xe0" b"\xff\xbc\x00\x08" b"\x3c\x1c\x00\x02"
+    kwargs = {"data": data, "mem_addr": 0x10000110, "num_inst": 3, "opt_level": 0}
+
+    n32 = pyvex.IRSB(arch=pyvex.ARCH_MIPSN32_BE, **kwargs)
+    m64 = pyvex.IRSB(arch=pyvex.ARCH_MIPS64_BE, **kwargs)
+    m32 = pyvex.IRSB(arch=pyvex.ARCH_MIPS32_BE, **kwargs)
+
+    assert n32.instructions == 3
+    assert n32.size == 12
+    # n32 must lift exactly as the 64-bit architecture does.
+    assert [str(stmt) for stmt in n32.statements] == [str(stmt) for stmt in m64.statements]
+    assert "Ity_I64" in n32.tyenv.types
+    # The 32-bit guest has no 64-bit value anywhere, which is the store being silently narrowed.
+    assert "Ity_I64" not in m32.tyenv.types
+
+    # The word size is the only thing n32 does not share with the 64-bit architecture.
+    assert pyvex.ARCH_MIPSN32_BE.bits == 32
+    assert pyvex.ARCH_MIPSN32_BE.vex_arch == pyvex.ARCH_MIPS64_BE.vex_arch
+
+
+if __name__ == "__main__":
+    test_mipsn32_uses_the_64_bit_guest()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

MIPS n32 lifts nothing. `main` at `0x10000110` in the chain's n32 fixture `n32_be_static` is 18 instructions of ordinary MIPS64 code, and every block of it comes back undecodable:

```
$ pyvex.lift(<72 bytes of main>, 0x10000110, archinfo.ArchMIPSN32(BE), opt_level=0)
  arch.bits=32  arch.vex_arch=VexArchMIPS64
  size=0  instructions=0  jumpkind=Ijk_NoDecode  Ity_I64 present=False
  instruction_addresses=()
```

The same bytes with `ArchMIPS64` give `size=44  instructions=11  jumpkind=Ijk_Call`. Nothing is recovered for an n32 or O64 object: no blocks, so no functions, no calls and no data references.

### Root cause

`LibVEXLifter` is selected by architecture *name*, not by `vex_arch`, and `MIPSN32` is not in `LIBVEX_SUPPORTED_ARCHES` in `pyvex/lifting/libvex.py`. The name misses, no libVEX lifter is registered for the architecture, and the block falls through to `Ijk_NoDecode` with size 0 even though `arch.vex_arch` already reads `VexArchMIPS64`.

Falling back to `MIPS32` is not a repair. It lifts the same 44 bytes, but `sd $gp, 8($sp)` — the 64-bit spill in a non-leaf n32 prologue, at `0x10000114` — silently becomes a 4-byte store:

```
   05 | ------ IMark(0x10000114, 4, 0) ------      <- ArchMIPS32
   06 | t8 = GET:I32(sp)
   09 | t9 = GET:I32(gp)
   10 | STbe(t0) = t9
```
```
   07 | ------ IMark(0x10000114, 4, 0) ------      <- ArchMIPS64
   08 | t15 = GET:I64(sp)
   11 | t16 = GET:I64(gp)
   12 | STbe(t0) = t16
```

`Ity_I64` appears nowhere in the `MIPS32` type environment, so the 32-bit guest reports a block that decodes cleanly and stores the wrong width.

### Fix

Add `MIPSN32` to `LIBVEX_SUPPORTED_ARCHES` and to the `PyvexArch` guest and instruction-pointer tables, mapped to `VexArchMIPS64`, and export `ARCH_MIPSN32_BE` / `ARCH_MIPSN32_LE`. n32 and O64 differ from MIPS64 in pointer width, not in the instruction set, so the correct guest is the one that already exists; no new VEX guest is added and `libpyvex.so` is byte-identical either side of this change (sha256 `9e5b9532fde21223…` on both, in the before/after capture). The architecture's word size stays 32 while `vex_arch` is `VexArchMIPS64`, which is the whole of what n32 means here. After:

```
$ pyvex.lift(<72 bytes of main>, 0x10000110, archinfo.ArchMIPSN32(BE), opt_level=0)
  arch.bits=32  arch.vex_arch=VexArchMIPS64
  size=44  instructions=11  jumpkind=Ijk_Call  Ity_I64 present=True
```

statement for statement identical to the `ArchMIPS64` lift of the same bytes.

### Testing

`tests/test_mipsn32.py` lifts that prologue and pins that n32 decodes exactly as `ARCH_MIPS64_BE` does — same statement list — that `Ity_I64` is present for n32 and absent for `ARCH_MIPS32_BE`, and that `ARCH_MIPSN32_BE.bits` is 32 while its `vex_arch` equals the 64-bit architecture's. On the merge base it is 1 failed, `AttributeError: module 'pyvex' has no attribute 'ARCH_MIPSN32_BE'`; at this head, 1 passed.

These four must land together: with the loader and the architecture definition ahead of the lifter, `MIPSN32` resolves and reaches a lifter with no entry for it, and recovery on the affected objects drops to zero blocks. Merge order: archinfo 375, then pyvex 576, then cle 795, then angr 6982.

Validation: https://github.com/angr/pyvex/pull/576#issuecomment-5440375982

sync: angr/archinfo#375

session: mega-corpus