### PR TITLE
Mark GPL components as GPL-2.0-or-later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "pyvex"
 description = "A Python interface to libVEX and VEX IR"
-license = "BSD-2-Clause AND GPL-2.0-only"
+license = "BSD-2-Clause AND GPL-2.0-or-later"
 license-files = [
   "LICENSE",
   "pyvex_c/LICENSE",


### PR DESCRIPTION
PyVEX currently declares its GPL-licensed components as
`GPL-2.0-only`, but the distributed source notices grant GPL version 2
or later:

- [`vex/LICENSE.README`](https://github.com/angr/vex/blob/875f7c9a5f6be621b4f000c29c016e15ddf32207/LICENSE.README#L2-L8) applies GPL v2-or-later to LibVEX and its children.
- [`pyvex_c/pyvex.c`](https://github.com/angr/pyvex/blob/bdd5441035e02920eaa72c1c3cf9a4f0d572104d/pyvex_c/pyvex.c#L1-L7) specifies GPL version 2 or later.
- Individual LibVEX sources, such as [`libvex.h`](https://github.com/angr/vex/blob/875f7c9a5f6be621b4f000c29c016e15ddf32207/pub/libvex.h#L13-L16), carry the same notice.

Update the PEP 639/SPDX expression to
`BSD-2-Clause AND GPL-2.0-or-later` so it matches those source notices.

This is a metadata-only change with no runtime or build behavior changes.
