### PR TITLE
Bump vex for the RISC-V feq/flt IR type fix, and regress it

### DIFF
--- a/tests/test_riscv_fcmp.py
+++ b/tests/test_riscv_fcmp.py
@@ -1,4 +1,3 @@
-# pylint: disable=missing-class-docstring
 import os
 import unittest
 
@@ -32,23 +31,22 @@ def fcmp_encodings(data: bytes) -> dict[int, str]:
     return found
 
 
-class TestRiscvFcmp(unittest.TestCase):
-    @unittest.skipUnless(os.path.exists(RISCV_BINARY), "the angr/binaries checkout is not beside this one")
-    def test_float_comparisons_decode(self):
-        with open(RISCV_BINARY, "rb") as fp:
-            data = fp.read()
+@unittest.skipUnless(os.path.exists(RISCV_BINARY), "the angr/binaries checkout is not beside this one")
+def test_float_comparisons_decode():
+    with open(RISCV_BINARY, "rb") as fp:
+        data = fp.read()
 
-        encodings = fcmp_encodings(data)
-        assert len(encodings) >= 25, f"expected the fixture to carry comparisons, found {len(encodings)}"
+    encodings = fcmp_encodings(data)
+    assert len(encodings) >= 25, f"expected the fixture to carry comparisons, found {len(encodings)}"
 
-        undecoded = {}
-        for offset, mnemonic in encodings.items():
-            irsb = pyvex.lift(data[offset : offset + 4], RISCV_BASE + offset, pyvex.ARCH_RISCV64_LE)
-            if irsb.size != 4 or irsb.jumpkind == "Ijk_NoDecode":
-                undecoded[hex(RISCV_BASE + offset)] = mnemonic
+    undecoded = {}
+    for offset, mnemonic in encodings.items():
+        irsb = pyvex.lift(data[offset : offset + 4], RISCV_BASE + offset, pyvex.ARCH_RISCV64_LE)
+        if irsb.size != 4 or irsb.jumpkind == "Ijk_NoDecode":
+            undecoded[hex(RISCV_BASE + offset)] = mnemonic
 
-        assert not undecoded, f"pyvex failed to decode {len(undecoded)} float comparisons: {undecoded}"
+    assert not undecoded, f"pyvex failed to decode {len(undecoded)} float comparisons: {undecoded}"
 
 
 if __name__ == "__main__":
-    unittest.main()
+    test_float_comparisons_decode()

--- a/tests/test_riscv_fcmp.py
+++ b/tests/test_riscv_fcmp.py
@@ -1,0 +1,54 @@
+# pylint: disable=missing-class-docstring
+import os
+import unittest
+
+import pyvex
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests"))
+
+# A gcc-built RISC-V shared object whose .text carries feq.s, flt.s and flt.d.
+RISCV_BINARY = os.path.join(test_location, "riscv", "autotalent-autotalent.so")
+
+# It is not position independent and its .text sits at file offset + 0x400000.
+RISCV_BASE = 0x400000
+
+OP_FP = 0b1010011
+FCMP_S = 0b1010000  # funct7 of feq.s / flt.s / fle.s
+FCMP_D = 0b1010001  # funct7 of feq.d / flt.d / fle.d
+COMPARISONS = {0b000: "fle", 0b001: "flt", 0b010: "feq"}  # funct3
+
+
+def fcmp_encodings(data: bytes) -> dict[int, str]:
+    """Every OP-FP floating point comparison encoding in `data`, keyed by offset."""
+    found = {}
+    for offset in range(0, len(data) - 3, 2):
+        word = int.from_bytes(data[offset : offset + 4], "little")
+        funct7 = word >> 25
+        if word & 0b1111111 != OP_FP or funct7 not in (FCMP_S, FCMP_D):
+            continue
+        comparison = COMPARISONS.get((word >> 12) & 0b111)
+        if comparison is not None:
+            found[offset] = comparison + (".s" if funct7 == FCMP_S else ".d")
+    return found
+
+
+class TestRiscvFcmp(unittest.TestCase):
+    @unittest.skipUnless(os.path.exists(RISCV_BINARY), "the angr/binaries checkout is not beside this one")
+    def test_float_comparisons_decode(self):
+        with open(RISCV_BINARY, "rb") as fp:
+            data = fp.read()
+
+        encodings = fcmp_encodings(data)
+        assert len(encodings) >= 25, f"expected the fixture to carry comparisons, found {len(encodings)}"
+
+        undecoded = {}
+        for offset, mnemonic in encodings.items():
+            irsb = pyvex.lift(data[offset : offset + 4], RISCV_BASE + offset, pyvex.ARCH_RISCV64_LE)
+            if irsb.size != 4 or irsb.jumpkind == "Ijk_NoDecode":
+                undecoded[hex(RISCV_BASE + offset)] = mnemonic
+
+        assert not undecoded, f"pyvex failed to decode {len(undecoded)} float comparisons: {undecoded}"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

pyvex reports every RISC-V `feq.s`, `flt.s`, `feq.d` and `flt.d` as undecodable.
`pyvex.lift(bytes.fromhex("d3a5d8a1"), 0x402390, ARCH_RISCV64_LE)` — the
`feq.s a1, fa7, ft9` at `0x402390` in
`binaries/tests/riscv/autotalent-autotalent.so` — returns `size=0`,
`jumpkind=Ijk_NoDecode`, no statements, while the byte-identical `fle.s`
(`d385d8a1`) returns a normal four-byte block of 16 statements.

Nothing in the API says the failure is spurious, so every consumer treats the
bytes as data. A capstone linear disassembly of `.text` on the six RISC-V
objects in `angr/binaries`, re-lifted instruction by instruction, finds
50 instructions in this state — 25 of them in `autotalent-autotalent.so`.

### Root cause

Not in pyvex. vex's `dis_RV64F` and `dis_RV64D` hold the comparison result in an
`Ity_I32` temporary and assign the `Ity_I1` output of `Iop_CmpEQ32` straight
into it, so libVEX's sanity checker rejects the block:

```
ERROR = IRStmt.Put.Tmp: tmp and expr do not match
IN STATEMENT:  t3 = CmpEQ32(t2,0x40:I32)
vex: the `impossible' happened:  sanityCheckFail: exiting due to bad IR
```

`pyvex_c` catches the resulting `vpanic` and synthesises the zero-length
`Ijk_NoDecode` block a caller sees. The `fle` arm of the same `switch` already
wraps its comparisons in `unop(Iop_1Uto32, ...)`, which is why only `feq` and
`flt` are affected.

### Fix

Bump the `vex` submodule from `875f7c9` to `c2409bb`, the head of
`angr/vex` `fix/riscv-fcmp-i1-to-i32`, which wraps the `feq` and `flt` arms in
`unop(Iop_1Uto32, ...)` in both `dis_RV64F` and `dis_RV64D`. No pyvex code
changes.

**This pull request is blocked on that vex branch merging.** The pin names an
unmerged branch head, which cannot stand: once
https://github.com/angr/vex/pull/95 merges, the pin must be moved to the
resulting commit on vex `master` before this is merged.

### Testing

`tests/test_riscv_fcmp.py` scans `autotalent-autotalent.so` for every OP-FP
comparison encoding — 42 of them, 25 `feq`/`flt` and 17 `fle` — and asserts each
lifts to a four-byte block that is not `Ijk_NoDecode`. Against the previous pin
it fails with `pyvex failed to decode 25 float comparisons`, naming
`0x402390: feq.s` among them; against this one the suite is 65 passed. It skips
when the `angr/binaries` checkout is not beside pyvex, because the standalone
`Test` matrix job checks out neither it nor any sibling.

The same census that produced the 50 above returns 0 across all six fixtures at
this pin.

Validation: https://github.com/angr/pyvex/pull/578#issuecomment-5460912729

session: sharpen
