### PR TITLE
Lifting: Decode x86 16-bit addressing modes correctly

### DIFF
--- a/tests/test_x86_addr16.py
+++ b/tests/test_x86_addr16.py
@@ -1,0 +1,167 @@
+import copy
+import re
+
+import pyvex
+
+# The 16-bit r/m table -- Intel SDM Vol. 2A, Table 2-1. It is not the table the 32-bit
+# addressing modes use: r/m 4 is (%si) here and (%esp)+SIB there. mod 0 r/m 6 is a bare
+# 16-bit literal address rather than (%bp), so it has no entry.
+RM16 = {
+    0: ("ebx", "esi"),
+    1: ("ebx", "edi"),
+    2: ("ebp", "esi"),
+    3: ("ebp", "edi"),
+    4: ("esi", None),
+    5: ("edi", None),
+    6: ("ebp", None),
+    7: ("ebx", None),
+}
+
+_GET16 = re.compile(r"GET:I16\(offset=(\d+)\)")
+
+
+def _lift(data):
+    # The trailing ret keeps the amode's displacement and immediate inside the buffer.
+    return pyvex.IRSB(data + b"\xc3", 0x400000, pyvex.ARCH_X86, opt_level=0, num_inst=1)
+
+
+def _regs_read(irsb):
+    """The names of the 16-bit guest registers the block reads."""
+    text = " ".join(str(stmt) for stmt in irsb.statements)
+    return {pyvex.ARCH_X86.translate_register_name(int(off), 2) for off in _GET16.findall(text)}
+
+
+def _text(irsb):
+    return " ".join(str(stmt) for stmt in irsb.statements)
+
+
+def test_addr16_modrm_reads_the_right_registers():
+    """
+    A 0x67 prefix in 32-bit mode selects 16-bit addressing, which uses its own r/m table.
+    disAMode16 indexed the general-register file with the raw r/m value instead, so
+    `67 8b 47 10` -- mov 0x10(%bx),%eax -- decoded without complaint and read %di. The four
+    base+index forms had no implementation at all and came back Ijk_NoDecode.
+    """
+    for mod, disp, size in ((0, b"", 3), (1, b"\x10", 4), (2, b"\x34\x12", 5)):
+        for rm in range(8):
+            if mod == 0 and rm == 6:
+                continue  # a bare 16-bit literal address; see below
+            irsb = _lift(bytes([0x67, 0x8B, (mod << 6) | rm]) + disp)
+            base, index = RM16[rm]
+            assert irsb.jumpkind == "Ijk_Boring", (mod, rm)
+            assert irsb.size == size, (mod, rm)
+            assert _regs_read(irsb) == ({base} if index is None else {base, index}), (mod, rm)
+
+
+def test_addr16_bare_literal_address():
+    # mod 0 r/m 6 is a 16-bit absolute address, not (%bp). This is the one form that was
+    # already right, and it is here so the rest of the table has a control.
+    irsb = _lift(b"\x67\x8b\x06\x34\x12")  # mov 0x1234,%eax
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 5
+    assert _regs_read(irsb) == set()
+
+
+def test_addr16_negative_disp8():
+    # getSDisp8 sign-extends to 32 bits and the result went straight into mkU16, whose
+    # `vassert(i < 65536)` failed, so every negative 8-bit displacement refused to decode.
+    irsb = _lift(b"\x67\x8b\x47\xf0")  # mov -0x10(%bx),%eax
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 4
+    assert _regs_read(irsb) == {"ebx"}
+    assert "0xfff0" in _text(irsb)
+
+
+def test_addr16_segment_override():
+    # The effective address wraps within 64K and is then widened to 32 bits, and only after
+    # that does the segment base get added. It used to reach handleSegOverride as an Ity_I16,
+    # which builds a call taking a 32-bit address, and the block did not decode.
+    irsb = _lift(b"\x67\x64\x8b\x47\x10")  # mov %fs:0x10(%bx),%eax
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 5
+    assert _regs_read(irsb) == {"ebx", "fs"}
+    assert "x86g_use_seg_selector" in _text(irsb)
+
+
+def test_addr16_immediate_follows_the_16_bit_amode():
+    """
+    lengthAMode dispatched on the processor mode while disAMode dispatched on the address
+    size in effect for the instruction, so a 0x67-prefixed amode was decoded 16-bit and
+    measured 32-bit. Everything that locates its immediate with lengthAMode -- the Grp1/2/3/5/8
+    extensions, SHLD/SHRD and the FPU escapes -- then read the immediate from the wrong byte.
+    """
+    # addl $5, 0x1234. The immediate used to be taken from 0x34, the low byte of the
+    # displacement, because a bare 16-bit literal address was measured as one byte.
+    irsb = _lift(b"\x67\x83\x06\x34\x12\x05")
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 6
+    assert "0x00000005" in _text(irsb)
+    assert "0x00000034" not in _text(irsb)
+
+    # addl $5, (%di). The immediate used to be read three bytes past the end of the
+    # instruction, because (%di) was measured as the 32-bit disp32 form.
+    irsb = _lift(b"\x67\x83\x05\x05")
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 4
+    assert _regs_read(irsb) == {"edi"}
+    assert "0x00000005" in _text(irsb)
+
+
+def _real_mode_arch():
+    """A copy of ARCH_X86 with cr0.PE clear. ARCH_X86 is a module-level singleton, so it
+    must not be mutated in place."""
+    arch = copy.deepcopy(pyvex.ARCH_X86)
+    arch.vex_archinfo["x86_cr0"] = 0xFFFFFFFE
+    return arch
+
+
+def test_addr16_in_real_mode_needs_no_prefix():
+    """
+    libVEX takes the address size from cr0 as well as from the prefix: with cr0.PE clear
+    every memory ModRM goes through the 16-bit path with no 0x67 in front of it. angr
+    lifts a BIOS in that mode, and it is where lengthAMode16's own lengths bite -- they
+    put the immediate of an instruction that has one at the wrong byte.
+    """
+    arch = _real_mode_arch()
+
+    # cmp dx, (%di). Same ModRM as the 0x67-prefixed case above, one byte shorter. Real
+    # mode makes the operand size 16 bits as well, so %dx is read as an I16 here too.
+    irsb = pyvex.IRSB(b"\x3b\x15" + b"\x90" * 4, 0xF9C98, arch, opt_level=0, num_inst=1)
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 2
+    assert _regs_read(irsb) == {"edi", "edx"}
+
+    # cmpw $0, 0xdf20. lengthAMode16 measured the bare 16-bit literal address as two
+    # bytes rather than three, so the immediate came from the high half of the address.
+    irsb = pyvex.IRSB(b"\x83\x3e\x20\xdf\x00" + b"\x90" * 4, 0xFE05D, arch, opt_level=0, num_inst=1)
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 5
+    assert "0xdf20" in _text(irsb)
+    assert "0xffdf" not in _text(irsb)
+
+    # add ax, (%bx,%si). The base+index forms have no implementation at all on the base,
+    # prefix or no prefix.
+    irsb = pyvex.IRSB(b"\x03\x00" + b"\x90" * 4, 0xF9C11, arch, opt_level=0, num_inst=1)
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 2
+    assert _regs_read(irsb) == {"ebx", "esi", "eax"}
+
+
+def test_addr32_is_unchanged():
+    # Control: without the prefix the same ModRM byte is 32-bit addressing off %edi, and
+    # nothing in this change may touch it.
+    irsb = _lift(b"\x8b\x47\x10")  # mov 0x10(%edi),%eax
+    assert irsb.jumpkind == "Ijk_Boring"
+    assert irsb.size == 3
+    assert _regs_read(irsb) == set()
+    assert "GET:I32(offset=36)" in _text(irsb)
+
+
+if __name__ == "__main__":
+    test_addr16_modrm_reads_the_right_registers()
+    test_addr16_bare_literal_address()
+    test_addr16_negative_disp8()
+    test_addr16_segment_override()
+    test_addr16_immediate_follows_the_16_bit_amode()
+    test_addr16_in_real_mode_needs_no_prefix()
+    test_addr32_is_unchanged()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`cmp dx, (%di)` reads `%bp`. This is `3b 15` at `0xf9c98` in `tests/i386/bios.bin.elf`, a SeaBIOS image, lifted in the real mode a BIOS runs in — `pyvex.IRSB(b"\x3b\x15", 0xf9c98, arch, opt_level=0, num_inst=1).pp()` on a copy of `ARCH_X86` whose `vex_archinfo["x86_cr0"]` is `0xFFFFFFFE`:

```
IRSB {
   [ temp declarations elided ]

   00 | ------ IMark(0xf9c98, 2, 0) ------
   01 | t4 = GET:I16(ebp)
   02 | t5 = 16Uto32(t4)
   03 | t3 = t5
   04 | t2 = GET:I16(edx)
   05 | t1 = LDle:I16(t3)
   06 | t0 = Sub16(t2,t1)
   [ 07-13 elided: the condition codes and %eip ]
   NEXT: PUT(eip) = 0x000f9c9a; Ijk_Boring
}
```

Line 01 is `ebp`. The instruction names `%di`.

It does not fault, does not decline, and comes back `Ijk_Boring` with the right length. Of the 24 memory forms of a 16-bit ModRM byte, one is right, eleven read the wrong base register like this, and twelve come back `Ijk_NoDecode` with size 0; put a segment override in front and all 24 refuse. A refusal ends the block at zero bytes, so it gets noticed; a wrong base register does not. The bytes reported in 2017 at https://github.com/angr/pyvex/issues/80 still show it: `67 20 74 6f` is `and %dh, 0x6f(%si)`, and on master it lifts cleanly reading `%sp`. Only the `sanityCheckFail` that issue was closed on is gone.

Both routes in are live. `67` in 32-bit mode is one. The other has no prefix: libVEX sends every memory ModRM through this code when `archinfo->x86_cr0 & 1` is clear, and angr sets that from a guest `mov cr0` through `engines/vex/heavy/dirty.py` and `engines/vex/lifter.py` -- `test_cfgemulated.py`'s `CFGEmulated` run over this file already takes that route four times. Over the 4,323 such instructions in that image's `.text`, 3,521 refuse, 687 compute the address from the wrong registers, 66 come out the wrong length, 2 emit no load or store to check, and 47 show no defect under those checks -- one of which takes the wrong immediate anyway.

### Root cause

Entirely in the submodule. `disAMode16` in `priv/guest_x86_toIR.c` passes the raw r/m field to `getIReg`, which numbers registers `ax cx dx bx sp bp si di`, while a 16-bit r/m field means `(%bx,%si) (%bx,%di) (%bp,%si) (%bp,%di) (%si) (%di) (%bp) (%bx)`, so `(%si)` reads `%sp` and `(%bx)` reads `%di`. The base+index forms have no implementation at all, a negative 8-bit displacement fails `mkU16`'s assertion, and a segment override reaches `handleSegOverride` as an `Ity_I16`. Separately, `lengthAMode` dispatches on the processor mode while `disAMode` dispatches on the address size, so a `67`-prefixed instruction's immediate is read from the wrong byte — and `lengthAMode16`'s own lengths are wrong for 17 of the 32 mod/rm combinations, which bites in real mode with no prefix: `83 3e 20 df 00`, `cmpw $0, 0xdf20`, takes `0xffdf` instead of `0`.

### Fix

Bump the `vex` submodule to angr/vex#97, which rewrites `disAMode16` and `lengthAMode16` around `mod` and `r/m` with the 16-bit table in one place, masks the displacement back to 16 bits, widens the effective address before the segment base is added, and points `lengthAMode` at `current_sz_addr`. That bump and `tests/test_x86_addr16.py` are the whole diff.

What a 16-bit address size means for the instructions that take no ModRM byte is deliberately still missing: `MOVS`, `CMPS`, `STOS`, `LODS` and `SCAS` address off `%esi`/`%edi`, `LOOP` and `JCXZ` count in `%ecx`, `XLAT` indexes off `%ebx`, the `A0`-`A3` moffs forms take a 32-bit offset, and in real mode `PUSH` and `POP` address the stack through 32-bit `%esp`. That is a separate change.

### Testing

`tests/test_x86_addr16.py` walks all 24 memory forms of the 16-bit ModRM byte at each of the three `mod` values and asserts that each reads exactly the registers the r/m table names and lifts to the right length; then the negative 8-bit displacement, the segment override, the immediate, and the real-mode route that needs no prefix, with the bare 16-bit literal address and an unprefixed 32-bit amode as controls. Five of its seven tests fail on the merge base and all seven pass here. Swapping only `libpyvex.so` under one fixed angr tree leaves angr's `tests/analyses/cfg` at the same counts with nothing failing on either side, `test_cfg_6` -- the BIOS binary above -- included.

The file lifts byte strings rather than loading a fixture. Real objects do contain these encodings -- `bios.bin.elf` holds all 24 forms -- but only the ecosystem job has a sibling checkout. The four-leg `Test` matrix and `Test (Pyodide)` each take this repository and its submodule and nothing else, and pyvex has no `conftest.py` and no skip guard, so a test opening an `angr/binaries` fixture would not skip on those five, it would fail. No pyvex test loads one today. Validation: https://github.com/angr/pyvex/pull/581#issuecomment-5560346884

Merge order: angr/vex#97 first. This head's `vex` submodule is `5e25551`, that pull request's head and one commit ahead of `vex` master, so merging this half alone would point `pyvex` master's submodule at a commit that is not on `vex` master. If it is squashed rather than merged, the submodule needs re-pointing at the squashed commit first. `angr/vex` is not in the CI repository list, so the `sync:` line below is a note to the reader, not an instruction to CI.

sync: angr/vex#97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen
