### PR TITLE
Add a regression for RISC-V feq/flt lifting

### DIFF
--- a/tests/test_riscv_fcmp.py
+++ b/tests/test_riscv_fcmp.py
@@ -1,0 +1,54 @@
+import os
+import unittest
+
+import pyvex
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests"))
+
+# A RISC-V shared object from angr/binaries whose .text carries feq.s, flt.s and flt.d.
+RISCV_BINARY = os.path.join(test_location, "riscv", "autotalent-autotalent.so")
+
+# Its first PT_LOAD maps file offset 0 at vaddr 0 and covers all of .text, so a .text
+# file offset is also an image offset. Lift each candidate at that offset with the
+# image placed at 0x400000.
+RISCV_BASE = 0x400000
+
+OP_FP = 0b1010011
+FCMP_S = 0b1010000  # funct7 of feq.s / flt.s / fle.s
+FCMP_D = 0b1010001  # funct7 of feq.d / flt.d / fle.d
+COMPARISONS = {0b000: "fle", 0b001: "flt", 0b010: "feq"}  # funct3
+
+
+def fcmp_encodings(data: bytes) -> dict[int, str]:
+    """Every OP-FP floating point comparison encoding in `data`, keyed by offset."""
+    found = {}
+    for offset in range(0, len(data) - 3, 2):
+        word = int.from_bytes(data[offset : offset + 4], "little")
+        funct7 = word >> 25
+        if word & 0b1111111 != OP_FP or funct7 not in (FCMP_S, FCMP_D):
+            continue
+        comparison = COMPARISONS.get((word >> 12) & 0b111)
+        if comparison is not None:
+            found[offset] = comparison + (".s" if funct7 == FCMP_S else ".d")
+    return found
+
+
+@unittest.skipUnless(os.path.exists(RISCV_BINARY), "the angr/binaries checkout is not beside this one")
+def test_float_comparisons_decode():
+    with open(RISCV_BINARY, "rb") as fp:
+        data = fp.read()
+
+    encodings = fcmp_encodings(data)
+    assert len(encodings) >= 25, f"expected the fixture to carry comparisons, found {len(encodings)}"
+
+    undecoded = {}
+    for offset, mnemonic in encodings.items():
+        irsb = pyvex.lift(data[offset : offset + 4], RISCV_BASE + offset, pyvex.ARCH_RISCV64_LE)
+        if irsb.size != 4 or irsb.jumpkind == "Ijk_NoDecode":
+            undecoded[hex(RISCV_BASE + offset)] = mnemonic
+
+    assert not undecoded, f"pyvex failed to decode {len(undecoded)} float comparisons: {undecoded}"
+
+
+if __name__ == "__main__":
+    test_float_comparisons_decode()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

pyvex reported every RISC-V `feq.s`, `flt.s`, `feq.d` and `flt.d` as
undecodable: `pyvex.lift` came back `size=0`, `jumpkind=Ijk_NoDecode`, no
statements, which every consumer reads as "these bytes are not code". #516
reports it from the outside, for `flt.s` and `flt.d`. pyvex at `2324a19` lifts
all four, and no test in the suite says so.

### Root cause

vex's `dis_RV64F` and `dis_RV64D` held the comparison result in an `Ity_I32`
temporary and assigned the `Ity_I1` output of `Iop_CmpEQ32` straight into it, so
libVEX failed its own sanity check:

```
ERROR = IRStmt.Put.Tmp: tmp and expr do not match
IN STATEMENT:  t3 = CmpEQ32(t2,0x40:I32)
vex: the `impossible' happened:  sanityCheckFail: exiting due to bad IR
```

and `pyvex_c` turned the `vpanic` into that fabricated zero-length block.

vex's Valgrind 3.27.1 import repairs it from the other end: the temporary is
`Ity_I1` and the result is widened at the point of use with
`unop(Iop_1Uto64, ...)`. The import reached this repository in `930d6dc` (#582),
and `2324a19` pins `e3062871`, which carries it as vex `1ecc894`.

### Fix

No production change. This is the regression the repair never got. It
re-proposes the test from #578, which was closed together with the pre-import
patch it had been written against, as that closing comment said it would be.

The direction is worth stating, because it reverses. Before the import the fault
was an `Ity_I1` value going into an `Ity_I32` temporary, and the patch wrapped the
`feq` and `flt` arms in `unop(Iop_1Uto32, ...)`. Applied
on top of the import, that same patch is the same fault with its sign flipped: an
`Ity_I32` value into an `Ity_I1` temporary. This test fails on it, which is how
the branch was caught; neither pull request merged. The validation comment has
the tree hash and the counts.

### Testing

`tests/test_riscv_fcmp.py` scans `binaries/tests/riscv/autotalent-autotalent.so`
— a RISC-V shared object already on `angr/binaries` master — for every OP-FP
comparison encoding and asserts each one lifts to a four-byte block that is not
`Ijk_NoDecode`. It skips when the `angr/binaries` checkout is not beside pyvex,
so it runs in the `ecosystem` job and skips in the standalone `Test` matrix,
which checks out neither that repository nor any sibling.

Validation: https://github.com/angr/pyvex/pull/585#issuecomment-5592939646

session: sharpen
