### PR TITLE
Clear every read-only region slot when deregistering

### DIFF
--- a/pyvex_c/analysis.c
+++ b/pyvex_c/analysis.c
@@ -480,8 +480,8 @@ Bool register_readonly_region(ULong start, ULong size, unsigned char* content)
 
 void deregister_all_readonly_regions()
 {
+	memset(regions, 0, sizeof(Region) * next_unused_region_id);
 	next_unused_region_id = 0;
-	regions[next_unused_region_id].in_use = 0;
 }
 
 Bool load_value(ULong addr, int size, int endness, void *value) {

--- a/tests/test_ro_region_const_fold_amd64.py
+++ b/tests/test_ro_region_const_fold_amd64.py
@@ -94,6 +94,34 @@ class TestRoRegionConstFoldAmd64(unittest.TestCase):
         finally:
             pyvex.pvc.deregister_all_readonly_regions()
 
+    def test_folds_again_after_a_deregister_and_reregister_cycle(self):
+        # Regression: deregister_all_readonly_regions() cleared only the first slot, so the slots after it kept
+        # in_use set. The next registration pass then took register_readonly_region's overwrite path without
+        # incrementing the region count, and the following region overwrote that slot, silently dropping one.
+        decoy_lo = bytearray(b"\x00" * 16)
+        decoy_hi = bytearray(b"\x33" * 16)
+        region = struct.pack("<Q", TARGET)
+        for _ in range(4):
+            bufs = [
+                (0x1_4000_0000, len(decoy_lo), pyvex.ffi.from_buffer(decoy_lo)),
+                (SLOT_ADDR, len(region), pyvex.ffi.from_buffer(region)),
+                (0x1_4000_9000, len(decoy_hi), pyvex.ffi.from_buffer(decoy_hi)),
+            ]
+            for addr, size, buf in bufs:
+                assert pyvex.pvc.register_readonly_region(addr, size, buf)
+            try:
+                irsb = pyvex.lift(
+                    b"\xff\x15\xfa\x00\x00\x00",
+                    0x1_4000_1000,
+                    pyvex.ARCH_AMD64,
+                    load_from_ro_regions=True,
+                    const_prop=True,
+                    collect_data_refs=True,
+                )
+                self._assert_next_tmp_folded(irsb)
+            finally:
+                pyvex.pvc.deregister_all_readonly_regions()
+
     def test_unregistered_region_does_not_fold(self):
         irsb = pyvex.lift(
             b"\xff\x15\xfa\x00\x00\x00",


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Running `CFGFast` a second time in one Python process, on a fresh `Project` each time, gives a
different CFG. On `binaries/tests/mips/ld.so.1` the answer alternates with the run index:

```
run0 nodes=6073 edges=10078 funcs=325
run1 nodes=6072 edges=10078 funcs=324
run2 nodes=6073 edges=10078 funcs=325
run3 nodes=6072 edges=10078 funcs=324
```

Ten runs give exactly two results, strictly alternating, with `PYTHONHASHSEED=0`. The odd runs
lose the function at `0x416a40` and let the block at `0x416a34` run past it.
`binaries/tests/mipsel/darpa_ping` is worse: run 0 recovers 206 functions, and every run after
it recovers 130.

### Root cause

`deregister_all_readonly_regions()` in `pyvex_c/analysis.c` resets the region count but clears
`in_use` on slot 0 only:

```c
void deregister_all_readonly_regions()
{
	next_unused_region_id = 0;
	regions[next_unused_region_id].in_use = 0;
}
```

Slots 1..N-1 keep `in_use` set along with the previous caller's start address. On the next
registration pass `register_readonly_region()` lands on such a stale slot, matches
`regions[pos].start == start`, takes the overwrite branch and returns **without incrementing
`next_unused_region_id`**. The region registered after it then overwrites that same slot. One
region is dropped, and every call still returns `True`.

The array is process-global, so the first registration pass in a process is always right and
the damage starts on the second.

`CFGFast._lifter_register_readonly_regions` registers one region per segment on MIPS and ARM,
plus one for `.got` on MIPS, and deregisters them when the analysis finishes. On `ld.so.1` that
is four regions, and the pass-by-pass simulation of the C algorithm over them is:

```
round 0: nothing dropped            lookup(0x432f8c) -> segment@0x432d50
round 1: segment@0x432d50 DROPPED   lookup(0x432f8c) -> None
round 2: .got DROPPED               lookup(0x432f8c) -> segment@0x432d50
round 3: segment@0x432d50 DROPPED   lookup(0x432f8c) -> None
```

`0x432f8c` is in `.data.rel.ro` and only the segment at `0x432d50` covers it, so on the odd
rounds the load from it stops folding. That load is the second half of the call chain at the
end of the block at `0x416950`:

```
0x416978  lw   $s2, -0x7f90($gp)    gp=0x43b010 -> reads 0x433080 (.got)         = 0x432f00
0x416980  lw   $t9, 0x8c($s2)                   -> reads 0x432f8c (.data.rel.ro) = 0x416a40
0x416994  jalr $t9
```

Without the fold `MipsElfFastResolver` cannot resolve the call, so no function is created at
`0x416a40` and the padding at `0x416a34` is absorbed into a longer block.

The run that keeps the function is the correct one. `_dl_make_stack_executable` is at
`0x416950` with size `0xe4`, so it ends at `0x416a34`; `0x416a34`, `0x416a38` and `0x416a3c`
are three `move $at, $at` nops padding to the `0x10` boundary; a whole-image 4-byte scan finds
exactly one word equal to `0x416a40` and none equal to `0x416a34`; and `0x416a40` begins
`lui $gp, 0x2 ; addiu $gp, $gp, 0x45d0 ; addu $gp, $gp, $t9`, the MIPS PIC `_gp_disp` prologue,
which yields the module's `$gp` (`0x43b010`) only when `$t9` holds the function's own address.

### Fix

`deregister_all_readonly_regions()` clears every slot it handed out instead of the first one,
so the array really is empty afterwards and the next pass registers into it from scratch.

The overwrite branch in `register_readonly_region()` is left alone: not incrementing the count
is correct for an overwrite, and `deregister_all_readonly_regions()` is the function that fails
to restore the invariant it relies on.

### Testing

`tests/test_ro_region_const_fold_amd64.py` gains
`test_folds_again_after_a_deregister_and_reregister_cycle`, which registers three regions in
ascending order, folds a load from the middle one, deregisters, and repeats four times. It
fails on master on the second round with `AssertionError: 2 not found in {}`, standalone as
well as with the rest of the file, and passes with this change.

With the change, `CFGFast` on `binaries/tests/mips/ld.so.1` gives one result over ten
in-process runs instead of two, and `binaries/tests/mipsel/darpa_ping` gives 206 functions on
every run instead of 206 then 130. angr's `tests/analyses/cfg/` is unchanged: 238 passed, 9
skipped on both arms.

Validation: https://github.com/angr/pyvex/pull/586#issuecomment-5614491590

session: sharpen
